### PR TITLE
Vanilla ruleset should ban j_mp_hanging_chad

### DIFF
--- a/rulesets/vanilla.lua
+++ b/rulesets/vanilla.lua
@@ -1,7 +1,9 @@
 MP.Ruleset({
 	key = "vanilla",
 	multiplayer_content = false,
-	banned_jokers = {},
+	banned_jokers = {
+		"j_mp_hanging_chad",
+	},
 	banned_consumables = {},
 	banned_vouchers = {},
 	banned_enhancements = {},


### PR DESCRIPTION
Quick fix because multiplayer_content doesn't seem to do anything for now.