### PR TITLE
Fix end round events triggering twice under specific circumstances

### DIFF
--- a/ui/game.lua
+++ b/ui/game.lua
@@ -928,6 +928,7 @@ end
 
 function MP.end_round()
 	if MP.GAME.antes_keyed[MP.GAME.ante_key] then
+		-- Prevent MP.end_round() from triggering multiple times at the end of a pvp round
 		return
 	end
 	G.GAME.blind.in_blind = false

--- a/ui/game.lua
+++ b/ui/game.lua
@@ -927,6 +927,9 @@ function Game:update_new_round(dt)
 end
 
 function MP.end_round()
+	if MP.GAME.antes_keyed[MP.GAME.ante_key] then
+		return
+	end
 	G.GAME.blind.in_blind = false
 	local game_over = false
 	local game_won = false


### PR DESCRIPTION
If a player's last hand is played right before the nemesis' hand finishes calculating, end of round events are triggered twice, as seen in this [clip](https://youtu.be/w0Q7mKQNLyI?t=254) (Invisible Joker goes from 0/2 to 2/2 after just one round).

We can implement the same fix used for `ease_ante()` but for `MP.end_round()`. By adding an `ante_key` check at the start of the function, the second `MP.end_round()` would not trigger.