### PR TITLE
Fix double end of round events (for real this time hopefully)

### DIFF
--- a/ui/game.lua
+++ b/ui/game.lua
@@ -870,11 +870,11 @@ function Game:update_hand_played(dt)
 						offset = { x = 0, y = -1.5 },
 						major = G.play,
 					})
-					if G.hand.cards[1] then
+					if G.hand.cards[1] and G.STATE == G.STATES.HAND_PLAYED then
 						eval_hand_and_jokers()
 						G.FUNCS.draw_from_hand_to_discard()
 					end
-				elseif not MP.GAME.end_pvp then
+				elseif not MP.GAME.end_pvp and G.STATE == G.STATES.HAND_PLAYED then
 					G.STATE_COMPLETE = false
 					G.STATE = G.STATES.DRAW_TO_HAND
 				end


### PR DESCRIPTION
Old fix didn't work because I forgot to test the case where one player still has some remaining hands and the other ran out of hands. Also old fix didn't change G.STATE, so you're just stuck and can't cash out at the end of pvp, oops... Thank you Virtualized for reverting that 😓

Anyway, I found a better fix that actually works. Here's the full reason why the bug happens (as seen in this [clip](https://youtu.be/w0Q7mKQNLyI?t=254))
When G.STATE is G.STATES.HAND_PLAYED, `update_hand_played` is called every dt. If `MP.GAME.end_pvp` is true, G.STATE is changed to G.STATES.NEW_ROUND, and the first `MP.end_round()` would trigger. However, the entire event of `update_hand_played` (line 857 to 883 of `ui/game.lua`) is still queued up in the event queue, and would still be executed shortly after. The reason why the player is seen drawing an additional five cards even after the round ends in the clip, is because G.STATE is changed to G.STATES.DRAW_TO_HAND in line 879. After this, G.STATE will change to G.STATES.SELECTING_HAND, then because `MP.GAME.end_pvp` was switched to true a second time (this depends on when the hands were played relative to each other), `update_selecting_hand` will change G.STATE to G.STATES.NEW_ROUND a second time, triggering the second `MP.end_round()`.

The solution would be to add a G.STATE check before switching states. If G.STATE is not G.STATES.HAND_PLAYED (because `MP.GAME.end_pvp` is true), these events should do nothing, and leave all the calculations to `MP.end_round()`.