### PR TITLE
Add seed logging if a player leaves the game early

### DIFF
--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -791,7 +791,7 @@ function Game:update(dt)
 						log = log .. string.format(" (%s: %s) ", k, v)
 					end
 				end
-				if parsedAction.action == "receiveEndGameJokers" and last_game_seed then
+				if (parsedAction.action == "receiveEndGameJokers" or parsedAction.action == "stopGame") and last_game_seed then
 					log = log .. string.format(" (seed: %s) ", last_game_seed)
 				end
 				sendTraceMessage(log, "MULTIPLAYER")

--- a/ui/game.lua
+++ b/ui/game.lua
@@ -883,7 +883,7 @@ function Game:update_hand_played(dt)
 		}))
 	end
 
-	if MP.GAME.end_pvp then
+	if MP.GAME.end_pvp and MP.is_pvp_boss() then
 		G.STATE_COMPLETE = false
 		G.STATE = G.STATES.NEW_ROUND
 		MP.GAME.end_pvp = false


### PR DESCRIPTION
Currently, the seed would not appear in the log if a player left the game early.
Also `update_hand_played` should only end the round if both `MP.GAME.end_pvp` and `MP.is_pvp_boss()` are true.