### PR TITLE
Asteroid: add explicit priority order for highest-level hand selection

### DIFF
--- a/compatibility/UpgradeMod.lua
+++ b/compatibility/UpgradeMod.lua
@@ -1,20 +1,48 @@
 if SMODS.Mods["upgrademod"] and SMODS.Mods["upgrademod"].can_load then
     function action_asteroid()
+        local hand_priority = {
+            ["Flush Five"] = 1,
+            ["Flush House"] = 2,
+            ["Five of a Kind"] = 3,
+            ["Straight Flush"] = 4,
+            ["Four of a Kind"] = 5,
+            ["Full House"] = 6,
+            ["Flush"] = 7,
+            ["Straight"] = 8,
+            ["Three of a Kind"] = 9,
+            ["Two Pair"] = 11,
+            ["Pair"] = 12,
+            ["High Card"] = 13
+        }
         local hand_type = "High Card"
         local max_level = 0
+
         for k, v in pairs(G.GAME.hands) do
-            if to_big(v.level) > to_big(max_level) then
+            if to_big(v.level) > to_big(max_level) or
+                (to_big(v.level) == to_big(max_level) and
+                    hand_priority[k] < hand_priority[hand_type]) then
                 hand_type = k
                 max_level = v.level
             end
         end
-        update_hand_text({ sound = "button", volume = 0.7, pitch = 0.8, delay = 0.3 }, {
-            handname = localize(hand_type, "poker_hands"),
-            chips = G.GAME.hands[hand_type].chips,
-            mult = G.GAME.hands[hand_type].mult,
-            level = G.GAME.hands[hand_type].level,
-        })
-        level_up_hand(nil, hand_type, false, -((asteroid_factor or 1) * (planet_level or 1)))
+
+        update_hand_text(
+            { sound = "button", volume = 0.7, pitch = 0.8, delay = 0.3 },
+            {
+                handname = localize(hand_type, "poker_hands"),
+                chips = G.GAME.hands[hand_type].chips,
+                mult = G.GAME.hands[hand_type].mult,
+                level = G.GAME.hands[hand_type].level,
+            }
+        )
+
+        level_up_hand(
+            nil,
+            hand_type,
+            false,
+            -((asteroid_factor or 1) * (planet_level or 1))
+        )
+
         update_hand_text(
             { sound = "button", volume = 0.7, pitch = 1.1, delay = 0 },
             { mult = 0, chips = 0, handname = "", level = "" }

--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -35,7 +35,7 @@ local function action_lobbyInfo(host, hostHash, hostCached, guest, guestHash, gu
 	MP.LOBBY.host = { username = host, hash_str = hostHash, hash = hash(hostHash), cached = hostCached == "true" }
 	if guest ~= nil then
 		MP.LOBBY.guest =
-			{ username = guest, hash_str = guestHash, hash = hash(guestHash), cached = guestCached == "true" }
+		{ username = guest, hash_str = guestHash, hash = hash(guestHash), cached = guestCached == "true" }
 	else
 		MP.LOBBY.guest = {}
 	end
@@ -99,7 +99,7 @@ end
 ---@param skips_str string
 local function action_enemy_info(score_str, hands_left_str, skips_str, lives_str)
 	local score = MP.INSANE_INT.from_string(score_str)
-	
+
 	local hands_left = tonumber(hands_left_str)
 	local skips = tonumber(skips_str)
 	local lives = tonumber(lives_str)
@@ -336,10 +336,28 @@ end
 
 local action_asteroid = action_asteroid
 	or function()
+		local hand_priority = {
+			["Flush Five"] = 1,
+			["Flush House"] = 2,
+			["Five of a Kind"] = 3,
+			["Straight Flush"] = 4,
+			["Four of a Kind"] = 5,
+			["Full House"] = 6,
+			["Flush"] = 7,
+			["Straight"] = 8,
+			["Three of a Kind"] = 9,
+			["Two Pair"] = 11,
+			["Pair"] = 12,
+			["High Card"] = 13
+		}
 		local hand_type = "High Card"
 		local max_level = 0
+
+
 		for k, v in pairs(G.GAME.hands) do
-			if to_big(v.level) > to_big(max_level) then
+			if to_big(v.level) > to_big(max_level) or
+				(to_big(v.level) == to_big(max_level) and
+					hand_priority[k] < hand_priority[hand_type]) then
 				hand_type = k
 				max_level = v.level
 			end


### PR DESCRIPTION
feat(asteroid): implement priority order for hand level reduction

when asteroid event triggers, it now follows a strict priority order when
selecting which hand to delevel among those tied for highest level:

1. flush five
2. flush house
3. five of a kind
4. straight flush
5. four of a kind
6. full house
7. flush
8. straight
9. three of a kind
10. two pair
11. pair
12. high card

this creates a predictable deleveling sequence rather than arbitrary selection
among tied hands.

implementation:
- adds hand_priority lookup table
- modifies hand selection logic to consider priority when levels are equal
- maintains existing behavior when hands have different levels

testing:
- verified priority order works with multiple hands at same level