### PR TITLE
Implement tags for the Enemy Jokers screen

### DIFF
--- a/misc/utils.lua
+++ b/misc/utils.lua
@@ -428,8 +428,17 @@ function MP.UTILS.joker_to_string(card)
 	end
 
 	local edition = card.edition and MP.UTILS.reverse_key_value_pairs(card.edition, true)["true"] or "none"
+	local eternal_or_perishable = "none"
+	if card.ability then
+		if card.ability.eternal then
+			eternal_or_perishable = "eternal"
+		elseif card.ability.perishable then
+			eternal_or_perishable = "perishable"
+		end
+	end
+	local rental = (card.ability and card.ability.rental) and "rental" or "none"
 
-	local joker_string = card.config.center.key .. "-" .. edition
+	local joker_string = card.config.center.key .. "-" .. edition .. "-" .. eternal_or_perishable .. "-" .. rental
 
 	return joker_string
 end

--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -99,7 +99,7 @@ end
 ---@param skips_str string
 local function action_enemy_info(score_str, hands_left_str, skips_str, lives_str)
 	local score = MP.INSANE_INT.from_string(score_str)
-	
+
 	local hands_left = tonumber(hands_left_str)
 	local skips = tonumber(skips_str)
 	local lives = tonumber(lives_str)
@@ -494,6 +494,8 @@ function G.FUNCS.load_end_game_jokers()
 
 		local key = joker_params[1]
 		local edition = joker_params[2]
+		local eternal_or_perishable = joker_params[3]
+		local rental = joker_params[4]
 
 		local card = create_card("Joker", MP.end_game_jokers, false, nil, nil, nil, key)
 
@@ -501,6 +503,16 @@ function G.FUNCS.load_end_game_jokers()
 			card:set_edition({ [edition] = true }, true, true)
 		else
 			card:set_edition()
+		end
+
+		if eternal_or_perishable == "eternal" then
+			card:set_eternal(true)
+		elseif eternal_or_perishable == "perishable" then
+			card:set_perishable(true)
+		end
+
+		if rental == "rental" then
+			card:set_rental(true)
 		end
 
 		card:add_to_deck()


### PR DESCRIPTION
Expands the joker string representation to be "`joker_key`-`edition_or_none`-`eternal_or_perishable_or_none`-`rental_or_none`"

Demo:

![Screenshot 2025-05-19 192855](https://github.com/user-attachments/assets/9fbb749a-c59f-43a8-a099-8831e57f3119)

Semi-related, we are really hitting the ceiling on what's feasible with a one dimensional CSV payload. I don't know how it would be manageable to propagate Sell Value, Perishable rounds, and other values from scaling jokers with this current system. Maybe it's time to bite the bullet and switch to [JSON](https://github.com/rxi/json.lua) payloads.