### PR TITLE
Implement encoding and sending the entire joker card area and for the joker copied by Magnet

### DIFF
--- a/misc/utils.lua
+++ b/misc/utils.lua
@@ -517,10 +517,10 @@ end
 function MP.UTILS.str_decode_and_unpack(str)
 	local success, str_decoded, str_decompressed, str_unpacked
 	success, str_decoded = pcall(love.data.decode, "string", "base64", str)
-	if not success then return nil end
+	if not success then return nil, str_decoded end
 	success, str_decompressed = pcall(love.data.decompress, "string", "deflate", str_decoded)
-	if not success then return nil end
+	if not success then return nil, str_decompressed end
 	success, str_unpacked = pcall(STR_UNPACK_CHECKED, str_decompressed)
-	if not success then return nil end
+	if not success then return nil, str_unpacked end
 	return str_unpacked
 end

--- a/misc/utils.lua
+++ b/misc/utils.lua
@@ -457,3 +457,70 @@ function MP.UTILS.random_message()
 	}
 	return messages[math.random(1, #messages)]
 end
+
+-- From https://github.com/lunarmodules/Penlight (MIT license)
+local function save_global_env()
+	local env = {}
+	env.hook, env.mask, env.count = debug.gethook()
+
+	-- env.hook is "external hook" if is a C hook function
+	if env.hook ~= "external hook" then
+		debug.sethook()
+	end
+
+	env.string_mt = getmetatable("")
+	debug.setmetatable("", nil)
+	return env
+end
+
+-- From https://github.com/lunarmodules/Penlight (MIT license)
+local function restore_global_env(env)
+	if env then
+		debug.setmetatable("", env.string_mt)
+		if env.hook ~= "external hook" then
+			debug.sethook(env.hook, env.mask, env.count)
+		end
+	end
+end
+
+local function STR_UNPACK_CHECKED(str)
+	-- Code generated from STR_PACK should only return a table and nothing else
+	if str:sub(1, 8) ~= "return {" then
+		error("Invalid string header, expected \"return {...\"")
+	end
+
+	-- Protect against code injection by disallowing function definitions
+	-- This is a very naive check, but hopefully won't trigger false positives
+	if str:find("[^\"'%w_]function[^\"'%w_]") then
+		error("Function keyword detected")
+	end
+
+	-- Load with an empty environment, no functions or globals should be available
+	local chunk = assert(load(str, nil, "t", {}))
+	local global_env = save_global_env()
+	local success, str_unpacked = pcall(chunk)
+	restore_global_env(global_env)
+	if not success then
+		error(str_unpacked)
+	end
+
+	return str_unpacked
+end
+
+function MP.UTILS.str_pack_and_encode(data)
+	local str = STR_PACK(data)
+	local str_compressed = love.data.compress("string", "deflate", str)
+	local str_encoded = love.data.encode("string", "base64", str_compressed)
+	return str_encoded
+end
+
+function MP.UTILS.str_unpack_and_decode(str)
+	local success, str_decoded, str_decompressed, str_unpacked
+	success, str_decoded = pcall(love.data.decode, "string", "base64", str)
+	if not success then return nil end
+	success, str_decompressed = pcall(love.data.decompress, "string", "deflate", str_decoded)
+	if not success then return nil end
+	success, str_unpacked = pcall(STR_UNPACK_CHECKED, str_decompressed)
+	if not success then return nil end
+	return str_unpacked
+end

--- a/misc/utils.lua
+++ b/misc/utils.lua
@@ -514,7 +514,7 @@ function MP.UTILS.str_pack_and_encode(data)
 	return str_encoded
 end
 
-function MP.UTILS.str_unpack_and_decode(str)
+function MP.UTILS.str_decode_and_unpack(str)
 	local success, str_decoded, str_decompressed, str_unpacked
 	success, str_decoded = pcall(love.data.decode, "string", "base64", str)
 	if not success then return nil end

--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -492,17 +492,19 @@ local function action_magnet()
 end
 
 local function action_magnet_response(key)
-	local card_save = MP.UTILS.str_decode_and_unpack(key)
+	local card_save, success, err
+
+	card_save, err = MP.UTILS.str_decode_and_unpack(key)
 	if not card_save then
-		sendDebugMessage("Failed to unpack magnet joker", "MULTIPLAYER")
+		sendDebugMessage("Failed to unpack magnet joker: " .. tostring(err), "MULTIPLAYER")
 		return
 	end
 
 	local card = Card(G.jokers.T.x + G.jokers.T.w/2, G.jokers.T.y, G.CARD_W, G.CARD_H, G.P_CENTERS.j_joker, G.P_CENTERS.c_base)
 	-- Avoid crashing if the load function ends up indexing a nil value
-	local success = pcall(card.load, card, card_save)
+	success, err = pcall(card.load, card, card_save)
 	if not success then
-		sendDebugMessage("Failed to load magnet joker", "MULTIPLAYER")
+		sendDebugMessage("Failed to load magnet joker: " .. tostring(err), "MULTIPLAYER")
 		return
 	end
 
@@ -519,20 +521,22 @@ local function action_magnet_response(key)
 end
 
 function G.FUNCS.load_end_game_jokers()
+	local card_area_save, success, err
+
 	if not MP.end_game_jokers and not MP.end_game_jokers_payload then
 		return
 	end
 
-	local card_area_save = MP.UTILS.str_decode_and_unpack(MP.end_game_jokers_payload)
+	card_area_save, err = MP.UTILS.str_decode_and_unpack(MP.end_game_jokers_payload)
 	if not card_area_save then
-		sendDebugMessage("Failed to unpack enemy jokers", "MULTIPLAYER")
+		sendDebugMessage("Failed to unpack enemy jokers: " .. tostring(err), "MULTIPLAYER")
 		return
 	end
 
 	-- Avoid crashing if the load function ends up indexing a nil value
-	local success = pcall(MP.end_game_jokers.load, MP.end_game_jokers, card_area_save)
+	success, err = pcall(MP.end_game_jokers.load, MP.end_game_jokers, card_area_save)
 	if not success then
-		sendDebugMessage("Failed to load enemy jokers", "MULTIPLAYER")
+		sendDebugMessage("Failed to load enemy jokers: " .. tostring(err), "MULTIPLAYER")
 		-- Reset the card area if loading fails to avoid inconsistent state
 		MP.end_game_jokers:remove()
 		MP.end_game_jokers:init(


### PR DESCRIPTION
Alright, this is pretty ambitious. this PR makes use of the `CardArea` save and load functions in order to serialize the entire joker card area and send it over to the opponent in the end of the game. This means that every element of the `CardArea` and it's cards are preserved: `CardArea` size (which can be different than the starting size if Antimatter was bought), jokers edtions, tags, scaling, sell value and everything that is preserved when a run is saved.

![Screenshot 2025-05-21 161546](https://github.com/user-attachments/assets/32de2a09-6e85-4bbb-ab9f-39ec8a2259a2)

This is accomplished by using the `CardArea:save()` method in order to obtain the plain data table representation of the CardArea (including its jokers), string packing the table, compressing the string with DEFLATE and encoding the buffer with base64 before sending it. On the receiving end, the reverse operations are taken, with a lot of care in order to sandbox the unpacking of the table as much as possible (making sure the code only returns a table and nothing else, rejecting code that could contain a function definition, loading the chunk with an empty environment and running the chuck without access to string functions).

Some notes:
- This makes the logging of the enemy  jokers opaque, since what is logged is now base64 representation of compressed string of lua code. Maybe it should be added some explicit logging of the jokers.
- For jokers that change status at the end of round (e.g. Idol), when a player loses their last life, the joker will do its round end update before it's serialized, so the status that will ultimately show up for their opponent is not the status on the moment they lost, but the status of the next round that they didn't get to play. This is the same for Perishables remaining rounds (shows rounds remaining after the loss).
- Unrelated, but since the base Balatro game doesn't check or sandbox its save file in its own STR_UNPACK function, it is pretty easy to make malicious save files that execute arbitrary code. This is a pretty worrying safety concern, since most people wouldn't expect an untrusted save file to be a vector of Malware.

Leaving this a draft for now, would like some feedback.

Thanks to @Toneblock for bringing string packing to my attention.