### PR TITLE
Removed magnet until rework

### DIFF
--- a/objects/jokers/magnet.lua
+++ b/objects/jokers/magnet.lua
@@ -1,4 +1,4 @@
-SMODS.Atlas({
+--[[ SMODS.Atlas({
 	key = "magnet",
 	path = "j_magnet.png",
 	px = 71,
@@ -63,3 +63,4 @@ SMODS.Joker({
 		code = { "Virtualized" },
 	},
 })
+--]]


### PR DESCRIPTION
Until the advisors can come up with a rework we decided to temporarily remove magnet from the game due to the many issues it caused