### PR TITLE
MP.GAME.furthest_blind update and bug fix

### DIFF
--- a/ui/game.lua
+++ b/ui/game.lua
@@ -2142,6 +2142,17 @@ G.FUNCS.skip_blind = function(e)
 			MP.GAME.timer = MP.GAME.timer + MP.LOBBY.config.timer_increment_seconds
 		end
 		MP.ACTIONS.skip(G.GAME.skips)
+
+		--Update the furthest blind
+		local temp_furthest_blind = 0
+		if G.GAME.round_resets.blind_states.Big == "Skipped" then
+			temp_furthest_blind = G.GAME.round_resets.ante * 10 + 2
+		elseif G.GAME.round_resets.blind_states.Small == "Skipped" then
+			temp_furthest_blind = G.GAME.round_resets.ante * 10 + 1
+		end
+
+		MP.GAME.furthest_blind = (temp_furthest_blind > MP.GAME.furthest_blind) and temp_furthest_blind or MP.GAME.furthest_blind
+		MP.ACTIONS.set_furthest_blind(MP.GAME.furthest_blind)
 	end
 end
 


### PR DESCRIPTION
- Skipping now also counts as defeating a blind.
- Fix furthest blind being set to the value of the next boss blind instead of the current one.