### PR TITLE
Enhance logging for magnet joker and end game jokers

### DIFF
--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -518,7 +518,7 @@ local function action_magnet_response(key)
 
 	card_save, err = MP.UTILS.str_decode_and_unpack(key)
 	if not card_save then
-		sendDebugMessage(string.format("Failed to unpack magnet joker: %s", tostring(err)) , "MULTIPLAYER")
+		sendDebugMessage(string.format("Failed to unpack magnet joker: %s", err) , "MULTIPLAYER")
 		return
 	end
 
@@ -526,7 +526,7 @@ local function action_magnet_response(key)
 	-- Avoid crashing if the load function ends up indexing a nil value
 	success, err = pcall(card.load, card, card_save)
 	if not success then
-		sendDebugMessage(string.format("Failed to load magnet joker: %s", tostring(err)) , "MULTIPLAYER")
+		sendDebugMessage(string.format("Failed to load magnet joker: %s", err) , "MULTIPLAYER")
 		return
 	end
 
@@ -551,14 +551,14 @@ function G.FUNCS.load_end_game_jokers()
 
 	card_area_save, err = MP.UTILS.str_decode_and_unpack(MP.end_game_jokers_payload)
 	if not card_area_save then
-		sendDebugMessage(string.format("Failed to unpack enemy jokers: %s", tostring(err)) , "MULTIPLAYER")
+		sendDebugMessage(string.format("Failed to unpack enemy jokers: %s", err) , "MULTIPLAYER")
 		return
 	end
 
 	-- Avoid crashing if the load function ends up indexing a nil value
 	success, err = pcall(MP.end_game_jokers.load, MP.end_game_jokers, card_area_save)
 	if not success then
-		sendDebugMessage(string.format("Failed to load enemy jokers: %s", tostring(err)) , "MULTIPLAYER")
+		sendDebugMessage(string.format("Failed to load enemy jokers: %s", err) , "MULTIPLAYER")
 		-- Reset the card area if loading fails to avoid inconsistent state
 		MP.end_game_jokers:remove()
 		MP.end_game_jokers:init(

--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -539,7 +539,7 @@ local function action_magnet_response(key)
 
 	card:add_to_deck()
 	G.jokers:emplace(card)
-	sendTraceMessage(string.format("Recieved magnet joker: %s", MP.UTILS.joker_to_string(card)), "MULTIPLAYER")
+	sendTraceMessage(string.format("Received magnet joker: %s", MP.UTILS.joker_to_string(card)), "MULTIPLAYER")
 end
 
 function G.FUNCS.load_end_game_jokers()
@@ -577,7 +577,7 @@ function G.FUNCS.load_end_game_jokers()
 		for _, card in pairs(MP.end_game_jokers.cards) do
 			jokers_str = jokers_str .. ";" .. MP.UTILS.joker_to_string(card)
 		end
-		sendTraceMessage(string.format("Recieved end game jokers: %s", jokers_str), "MULTIPLAYER")
+		sendTraceMessage(string.format("Received end game jokers: %s", jokers_str), "MULTIPLAYER")
 	end
 end
 


### PR DESCRIPTION
Added logging of the jokers sent in their readable string form. It was only properly logging the received Nemesis jokers before. Important in order to adapt the Log Parser for this version.

The readable string form of the jokers can be parsed by matching to the following strings:

- "Sending end game jokers: %s" => End game jokers of the Client.
- "Received end game jokers: %s" => End game jokers of the Nemesis.