### PR TITLE
Compatibility with the recent update to Too Many Jokers

### DIFF
--- a/compatibility/TooManyJokers.lua
+++ b/compatibility/TooManyJokers.lua
@@ -1,0 +1,4 @@
+if TMJ then
+    TMJ.ALLOW_HIGHLIGHT = false --this is implemented in a hook, can't move it over here
+    G.FUNCS.tmj_spawn = function() error("This is not allowed in Multiplayer") end
+end


### PR DESCRIPTION
I've added a feature to TMJ that allows for the spawning in of cards. As of right now, TMJ does disable this feature when multiplayer is present. This PR moves that disabling over to Multiplayers side. I've left the TMJ-sided multiplayer checks in, not sure when I should remove them (of course leaving the one for TMJ.ALLOW_HIGHLIGHT). 