### PR TITLE
Rework Taxes

### DIFF
--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -64,9 +64,9 @@ return {
 			j_mp_taxes = {
 				name = "Taxes",
 				text = {
-					"When your {X:purple,C:white}Nemesis{} sells",
-					"a card, gain {C:mult}+#1#{} Mult at the",
-					"start of the next {C:attention}PvP Blind{}",
+					"{C:mult}+#1#{} Mult for every card your",
+					"{X:purple,C:white}Nemesis{} {C:attention}sold{} this run, updates",
+					"when {C:attention}PvP Blind{} is selected",
 					"{C:inactive}(Currently {C:mult}+#2#{C:inactive} Mult,",
 					"{C:inactive}will be at {C:mult}+#3#{C:inactive} Mult)",
 				},

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -65,8 +65,10 @@ return {
 				name = "Taxes",
 				text = {
 					"When your {X:purple,C:white}Nemesis{} sells",
-					"a joker gain {C:mult}+#1#{} Mult",
-					"{C:inactive}(Currently {C:mult}+#2#{C:inactive} Mult)",
+					"a card, gain {C:mult}+#1#{} Mult at the",
+					"start of the next {C:attention}PvP Blind{}",
+					"{C:inactive}(Currently {C:mult}+#2#{C:inactive} Mult,",
+					"{C:inactive}will be at {C:mult}+#3#{C:inactive} Mult)",
 				},
 			},
 			j_mp_magnet = {

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -269,6 +269,7 @@ return {
 			k_survival = "Survival",
 			k_survival_description = "The player who beats the farthest blind wins. No Nemesis blinds. This gamemode is a test of your ability to gradually build-up to the highest scoring Vanilla hands.",
 			k_oops_ex = "Oops!",
+			k_filed_ex = "Filed!",
 			k_timer = "Timer",
 			k_mods_list = "Mods List",
 			k_enemy_jokers = "Enemy Jokers",

--- a/lovely/game.toml
+++ b/lovely/game.toml
@@ -99,7 +99,7 @@ times = 1
 target = "card.lua"
 pattern = '''function Card:sell_card()'''
 position = 'after'
-payload = '''if MP.LOBBY.code and self.area == G.jokers then
+payload = '''if MP.LOBBY.code then
   MP.ACTIONS.sold_joker()
 end'''
 match_indent = true

--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -411,7 +411,7 @@ local action_asteroid = action_asteroid
 local function action_sold_joker()
 	local function juice_taxes(card)
 		if card then
-			card.ability.extra.mult = card.ability.extra.mult_gain + card.ability.extra.mult
+			card.ability.extra.mult_next = card.ability.extra.mult_gain + card.ability.extra.mult_next
 			card:juice_up()
 		end
 	end

--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -409,11 +409,10 @@ local action_asteroid = action_asteroid
 	end
 
 local function action_sold_joker()
+	-- HACK: this action is being sent when any card is being sold, since Taxes is now reworked
+	MP.GAME.enemy.sells = MP.GAME.enemy.sells + 1
 	local function juice_taxes(card)
-		if card then
-			card.ability.extra.mult_next = card.ability.extra.mult_gain + card.ability.extra.mult_next
-			card:juice_up()
-		end
+		card:juice_up()
 	end
 	MP.UTILS.run_for_each_joker("j_mp_taxes", juice_taxes)
 end

--- a/objects/jokers/taxes.lua
+++ b/objects/jokers/taxes.lua
@@ -8,17 +8,17 @@ SMODS.Atlas({
 SMODS.Joker({
 	key = "taxes",
 	atlas = "taxes",
-	rarity = 2,
-	cost = 6,
+	rarity = 1,
+	cost = 5,
 	unlocked = true,
 	discovered = true,
 	blueprint_compat = true,
 	eternal_compat = true,
 	perishable_compat = false,
-	config = { extra = { mult_gain = 5, mult = 0 } },
+	config = { extra = { mult_gain = 4, mult = 0, mult_next = 0 } },
 	loc_vars = function(self, info_queue, card)
 		MP.UTILS.add_nemesis_info(info_queue)
-		return { vars = { card.ability.extra.mult_gain, card.ability.extra.mult } }
+		return { vars = { card.ability.extra.mult_gain, card.ability.extra.mult, card.ability.extra.mult_next } }
 	end,
 	in_pool = function(self)
 		return MP.LOBBY.code and MP.LOBBY.config.multiplayer_jokers
@@ -28,6 +28,9 @@ SMODS.Joker({
 			return {
 				mult = card.ability.extra.mult,
 			}
+		elseif context.setting_blind and context.blind.key == "bl_mp_nemesis" then
+			card.ability.extra.mult = card.ability.extra.mult_next
+			card:juice_up()
 		end
 	end,
 	mp_credits = {

--- a/objects/jokers/taxes.lua
+++ b/objects/jokers/taxes.lua
@@ -1,3 +1,7 @@
+local function calculate_taxes_mult(card)
+	return MP.GAME.enemy.sells * card.ability.extra.mult_gain
+end
+
 SMODS.Atlas({
 	key = "taxes",
 	path = "j_taxes.png",
@@ -15,10 +19,10 @@ SMODS.Joker({
 	blueprint_compat = true,
 	eternal_compat = true,
 	perishable_compat = false,
-	config = { extra = { mult_gain = 4, mult = 0, mult_next = 0 } },
+	config = { extra = { mult_gain = 4, mult = 0} },
 	loc_vars = function(self, info_queue, card)
 		MP.UTILS.add_nemesis_info(info_queue)
-		return { vars = { card.ability.extra.mult_gain, card.ability.extra.mult, card.ability.extra.mult_next } }
+		return { vars = { card.ability.extra.mult_gain, card.ability.extra.mult, calculate_taxes_mult(card)} }
 	end,
 	in_pool = function(self)
 		return MP.LOBBY.code and MP.LOBBY.config.multiplayer_jokers
@@ -29,8 +33,8 @@ SMODS.Joker({
 				mult = card.ability.extra.mult,
 			}
 		elseif context.setting_blind and context.blind.key == "bl_mp_nemesis" then
-			card.ability.extra.mult = card.ability.extra.mult_next
-			card:juice_up()
+			card.ability.extra.mult = calculate_taxes_mult(card)
+			card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize('k_filed_ex')})
 		end
 	end,
 	mp_credits = {

--- a/objects/jokers/taxes.lua
+++ b/objects/jokers/taxes.lua
@@ -19,10 +19,10 @@ SMODS.Joker({
 	blueprint_compat = true,
 	eternal_compat = true,
 	perishable_compat = false,
-	config = { extra = { mult_gain = 4, mult = 0} },
+	config = { extra = { mult_gain = 4, mult = 0 } },
 	loc_vars = function(self, info_queue, card)
 		MP.UTILS.add_nemesis_info(info_queue)
-		return { vars = { card.ability.extra.mult_gain, card.ability.extra.mult, calculate_taxes_mult(card)} }
+		return { vars = { card.ability.extra.mult_gain, card.ability.extra.mult, calculate_taxes_mult(card) } }
 	end,
 	in_pool = function(self)
 		return MP.LOBBY.code and MP.LOBBY.config.multiplayer_jokers
@@ -34,7 +34,7 @@ SMODS.Joker({
 			}
 		elseif context.setting_blind and context.blind.key == "bl_mp_nemesis" then
 			card.ability.extra.mult = calculate_taxes_mult(card)
-			card_eval_status_text(card, 'extra', nil, nil, nil, {message = localize('k_filed_ex')})
+			card_eval_status_text(card, 'extra', nil, nil, nil, { message = localize('k_filed_ex') })
 		end
 	end,
 	mp_credits = {


### PR DESCRIPTION
Rework Taxes Joker to new advisors specification:

- Change rarity to common.
- Change cost to $5.
- New effect: gives +4 mult for each card your opponent sells (currently only works on jokers sold). Will keep track of everything sold by opponent and only increment mult at start of PvP.

There is a hack adopted in order for this to work for now: the `soldJoker` action is now being called on every card sold, not just jokers. This action should be renamed in order to actually reflect when its being called.
