### PR TITLE
Update lets_go_gambling.lua to remove ante based aspect of misfire qu…

### DIFF
--- a/objects/jokers/lets_go_gambling.lua
+++ b/objects/jokers/lets_go_gambling.lua
@@ -45,7 +45,7 @@ SMODS.Joker({
 				returns.dollars = card.ability.extra.dollars
 			end
 			if MP.is_pvp_boss() and 
-				pseudorandom("j_mp_lets_go_gambling" .. G.GAME.round_resets.ante)
+				pseudorandom("j_mp_lets_go_gambling_misfire")
 				< G.GAME.probabilities.normal / card.ability.extra.nemesis_odds
 			then
 				returns = returns or {}


### PR DESCRIPTION
…eue (but keep it separate)

it just makes more sense. misfire can only activate in pvp anyway