### PR TITLE
Add a "Ready Up" system in the Lobby for the guest

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -37,6 +37,7 @@ MP.LOBBY = {
 	host = {},
 	guest = {},
 	is_host = false,
+	ready_to_start = false,
 }
 MP.GAME = {}
 MP.UI = {}

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -179,6 +179,7 @@ return {
 			b_start = "START",
 			b_wait_for_host_start = { "WAITING FOR", "HOST TO START" },
 			b_wait_for_players = { "WAITING FOR", "PLAYERS" },
+			b_wait_for_guest_ready = { "WAITING FOR", "GUEST TO READY UP" },
 			b_lobby_options = "LOBBY OPTIONS",
 			b_copy_clipboard = "Copy to clipboard",
 			b_view_code = "VIEW CODE",

--- a/ui/lobby.lua
+++ b/ui/lobby.lua
@@ -199,20 +199,30 @@ function G.UIDEF.create_UIBox_lobby_menu()
 							mid = true,
 						},
 						nodes = {
-							Disableable_Button({
-								id = "lobby_menu_start",
-								button = "lobby_start_game",
-								colour = G.C.BLUE,
-								minw = 3.65,
-								minh = 1.55,
-								label = { localize("b_start") },
-								disabled_text = MP.LOBBY.is_host and localize("b_wait_for_players")
-									or localize("b_wait_for_host_start"),
-								scale = text_scale * 2,
-								col = true,
-								enabled_ref_table = MP.LOBBY,
-								enabled_ref_value = "ready_to_start",
-							}),
+							MP.LOBBY.is_host
+								and Disableable_Button({
+									id = "lobby_menu_start",
+									button = "lobby_start_game",
+									colour = G.C.BLUE,
+									minw = 3.65,
+									minh = 1.55,
+									label = { localize("b_start") },
+									disabled_text = MP.LOBBY.guest.username and localize("b_wait_for_guest_ready") or localize("b_wait_for_players"),
+									scale = text_scale * 2,
+									col = true,
+									enabled_ref_table = MP.LOBBY,
+									enabled_ref_value = "ready_to_start",
+								})
+								or UIBox_button({
+									id = "lobby_menu_start",
+									button = "lobby_ready_up",
+									colour = MP.LOBBY.ready_to_start and G.C.GREEN or G.C.RED,
+									minw = 3.65,
+									minh = 1.55,
+									label = { MP.LOBBY.ready_to_start and localize("b_unready") or localize("b_ready") },
+									scale = text_scale * 2,
+									col = true,
+								}),
 							{
 								n = G.UIT.C,
 								config = {
@@ -1074,6 +1084,14 @@ end
 
 function G.FUNCS.lobby_start_game(e)
 	MP.ACTIONS.start_game()
+end
+
+function G.FUNCS.lobby_ready_up(e)
+	if not MP.LOBBY.ready_to_start then
+		MP.ACTIONS.ready_lobby()
+	else
+		MP.ACTIONS.unready_lobby()
+	end
 end
 
 function G.FUNCS.lobby_options(e)


### PR DESCRIPTION
Adds a new "Ready Up" system in the lobby. Host will have to wait for the Guest to press the "Ready" button on their screen in order to start the game.

Players screens when the Guest is not ready:

<img width="1146" height="1198" alt="Screenshot 2025-07-14 205523" src="https://github.com/user-attachments/assets/109824af-465f-4185-860a-dfd155a96546" />

Players screens when the Guest is ready:

<img width="1147" height="1199" alt="Screenshot 2025-07-14 205539" src="https://github.com/user-attachments/assets/59137861-6d31-4e0d-a215-2eb009d802da" />

Will require an update to the server for this to work.