### PR TITLE
Cram more mods into modlist ui by tightening spacing/text

### DIFF
--- a/ui/lobby.lua
+++ b/ui/lobby.lua
@@ -796,7 +796,7 @@ function G.UIDEF.create_UIBox_view_hash(type)
 				{
 					n = G.UIT.C,
 					config = {
-						padding = 0.2,
+						padding = 0.07,
 						align = "cm",
 					},
 					nodes = MP.UI.hash_str_to_view(
@@ -820,7 +820,7 @@ function MP.UI.hash_str_to_view(str, text_colour)
 		table.insert(t, {
 			n = G.UIT.R,
 			config = {
-				padding = 0.05,
+				padding = 0.02,
 				align = "cm",
 			},
 			nodes = {
@@ -829,7 +829,7 @@ function MP.UI.hash_str_to_view(str, text_colour)
 					config = {
 						text = s,
 						shadow = true,
-						scale = 0.45,
+						scale = 0.4,
 						colour = text_colour,
 					},
 				},


### PR DESCRIPTION
**changes**
* container padding: 0.2 → 0.07
* row padding: 0.05 → 0.02
* text scale: 0.45 → 0.4
* **net result:** ~2x mod display capacity while remaining readable (tested w/ 24 mods)

**rationale**
interim hack which doesn't break readability, buys time while proper solution gets sorted.

Before:
<img width="2800" height="1652" alt="Screenshot 2025-07-21 at 20 29 00" src="https://github.com/user-attachments/assets/8e556e1b-a2ec-4ded-a107-546f2dcc3870" />

After:
<img width="1958" height="1116" alt="Screenshot 2025-07-21 at 20 29 37" src="https://github.com/user-attachments/assets/0916a276-f8f6-4e04-9cd3-d838e411ec22" />
