### PR TITLE
Make Speedrun create a Phantom Joker

### DIFF
--- a/objects/jokers/speedrun.lua
+++ b/objects/jokers/speedrun.lua
@@ -23,7 +23,13 @@ SMODS.Joker({
 		return MP.LOBBY.code and MP.LOBBY.config.multiplayer_jokers
 	end,
 	calculate = function(self, card, context)
-		if context.mp_speedrun and #G.consumeables.cards + G.GAME.consumeable_buffer < G.consumeables.config.card_limit then
+		if
+			context.cardarea == G.jokers
+			and context.joker_main
+			and (not card.edition or card.edition.type ~= "mp_phantom") 
+			and context.mp_speedrun 
+			and #G.consumeables.cards + G.GAME.consumeable_buffer < G.consumeables.config.card_limit
+		then
 			G.GAME.consumeable_buffer = G.GAME.consumeable_buffer + 1
 			G.E_MANAGER:add_event(Event({
 				trigger = 'before',
@@ -41,6 +47,16 @@ SMODS.Joker({
 				colour = G.C.SECONDARY_SET.Spectral,
 				card = card
 			}
+		end
+	end,
+	add_to_deck = function(self, card, from_debuffed)
+		if not from_debuffed and (not card.edition or card.edition.type ~= "mp_phantom") then
+			MP.ACTIONS.send_phantom("j_mp_speedrun")
+		end
+	end,
+	remove_from_deck = function(self, card, from_debuff)
+		if not from_debuff and (not card.edition or card.edition.type ~= "mp_phantom") then
+			MP.ACTIONS.remove_phantom("j_mp_speedrun")
 		end
 	end,
 	mp_credits = {


### PR DESCRIPTION
This makes logical sense for the joker. Based on a suggestion from here: https://discord.com/channels/1226193436521267223/1396398881054527498

The idea is that it *should* alert you that someone has picked up a speedrun, so you can know if you need to play fast or not, which helps balance it. As an example, if someone is playing carefully in a small blind while someone else is playing quick, they could see the speedrun first, and then the careful player gets punished through no fault of their own.

Not sure if this is something I can just suggest, but this code should do it.