### PR TITLE
Updated keyboard offsets for controller MP menus

### DIFF
--- a/ui/lobby.lua
+++ b/ui/lobby.lua
@@ -764,6 +764,7 @@ function G.UIDEF.create_UIBox_custom_seed_overlay()
 								ref_table = MP.LOBBY,
 								ref_value = "temp_seed",
 								prompt_text = localize("k_enter_seed"),
+								keyboard_offset = 4,
 								callback = function(val)
 									MP.LOBBY.config.custom_seed = MP.LOBBY.temp_seed
 									send_lobby_options()

--- a/ui/main_menu.lua
+++ b/ui/main_menu.lua
@@ -546,6 +546,7 @@ function G.UIDEF.create_UIBox_join_lobby_button()
 									ref_value = "temp_code",
 									extended_corpus = false,
 									keyboard_offset = 1,
+									keyboard_offset = 4,
 									minw = 5,
 									callback = function(val)
 										MP.ACTIONS.join_lobby(MP.LOBBY.temp_code)

--- a/ui/smods.lua
+++ b/ui/smods.lua
@@ -216,7 +216,7 @@ SMODS.Mods.Multiplayer.config_tab = function()
 						ref_table = MP.LOBBY,
 						ref_value = "username",
 						extended_corpus = true,
-						keyboard_offset = 1,
+						keyboard_offset = -3,
 						callback = function(val)
 							MP.UTILS.save_username(MP.LOBBY.username)
 						end,


### PR DESCRIPTION
Steammodded appears to have a bug that makes certain menu elements overlap the controller keyboard, making it look bad, and also harder to use. This changes the offsets of all the menus specific to the balatro multiplayer mod, to not be centered, which helps avoid this issue until it's fixed. It's a bit hacky, but it gets the job done and works on other screen sizes (as far as I can tell in testing on windowed mode)