### PR TITLE
Enhance double end prevention (#240)

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -117,6 +117,7 @@ function MP.reset_game_states()
 		ante_key = tostring(math.random()),
 		antes_keyed = {},
 		prevent_eval = false,
+		round_ended = false,
 		misprint_display = "",
 		spent_total = 0,
 		spent_before_shop = 0,

--- a/ui/game.lua
+++ b/ui/game.lua
@@ -1067,8 +1067,8 @@ function Game:update_new_round(dt)
 end
 
 function MP.end_round()
-	if MP.stop_ends then sendDebugMessage('Double-end prevented'); return end -- quick fix to prevent double ends?
-	MP.stop_ends = true
+	if MP.GAME.round_ended then sendDebugMessage('Double-end prevented'); return true end -- quick fix to prevent double ends?
+	MP.GAME.round_ended  = true
 	
 	G.GAME.blind.in_blind = false
 	local game_over = false
@@ -2368,7 +2368,7 @@ function G.FUNCS.select_blind(e)
 	MP.GAME.prevent_eval = false
 	select_blind_ref(e)
 	if MP.LOBBY.code then
-		MP.stop_ends = false -- wrapping blind so ends don't happen twice, referenced at start of MP.end_round
+		MP.GAME.round_ended = false -- wrapping blind so ends don't happen twice, referenced at start of MP.end_round
 		MP.GAME.ante_key = tostring(math.random())
 		MP.ACTIONS.play_hand(0, G.GAME.round_resets.hands)
 		MP.ACTIONS.new_round()


### PR DESCRIPTION
This PR addresses an issue where returning no value during the end_round call caused the function to be called again, resulting in infinite double-end prevention.

Enhanced the value being used to detect "stop ends" into being an MP.GAME var.