### PR TITLE
Add an enforced ban list to the ranked ruleset

### DIFF
--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -379,6 +379,7 @@ return {
 			k_reworked_objs = "Reworked #1#",
 			k_no_reworked_objs = "No Reworked #1#",
 			k_ruleset_disabled_smods_version = "SMODS Version #1# Required",
+			k_ruleset_disabled_banned_mod = "#1# is banned for use in this ruleset",
 			k_failed_to_join_lobby = "Failed to join lobby: #1#",
 			k_ante_number = "Ante #1#",
 			k_ante_range = "Ante #1#-#2#", -- For example, "Ante 1-2"

--- a/misc/utils.lua
+++ b/misc/utils.lua
@@ -841,21 +841,3 @@ end
 function MP.UTILS.is_weekly(arg)
 	return MP.UTILS.get_weekly() == arg and MP.LOBBY.config.ruleset == 'ruleset_mp_weekly'
 end
-
-function MP.UTILS.get_banned_mods()
-	return {
-		"Cryptid",
-		"GameSpeed",
-		"Talisman",
-		"Nopeus",
-		"Incantation",
-		"Brainstorm",
-		"Aura",
-		"NotJustYet",
-		"Showman",
-		"TagPreview",
-		"Saturn",
-		"TopDeckPreview",
-		"DVPreview"
-	},
-end

--- a/misc/utils.lua
+++ b/misc/utils.lua
@@ -841,3 +841,21 @@ end
 function MP.UTILS.is_weekly(arg)
 	return MP.UTILS.get_weekly() == arg and MP.LOBBY.config.ruleset == 'ruleset_mp_weekly'
 end
+
+function MP.UTILS.get_banned_mods()
+	return {
+		"Cryptid",
+		"GameSpeed",
+		"Talisman",
+		"Nopeus",
+		"Incantation",
+		"Brainstorm",
+		"Aura",
+		"NotJustYet",
+		"Showman",
+		"TagPreview",
+		"Saturn",
+		"TopDeckPreview",
+		"DVPreview"
+	},
+end

--- a/rulesets/ranked.lua
+++ b/rulesets/ranked.lua
@@ -104,15 +104,33 @@ MP.Ruleset({
 	forced_lobby_options = true,
 	is_disabled = function(self)
 		local required_version = "1.0.0~BETA-0506a"
+		local banned_mods = {
+			"Cryptid",
+			"GameSpeed",
+			"Talisman",
+			"Nopeus",
+			"Incantation",
+			"Brainstorm",
+			"Aura",
+			"NotJustYet",
+			"Showman",
+			"TagPreview",
+			"Saturn",
+			"TopDeckPreview",
+			"DVPreview"
+		}
+		
 		if SMODS.version ~= required_version then
 			return localize({type = "variable", key="k_ruleset_disabled_smods_version", vars = {required_version}})
 		end
 		if not MP.INTEGRATIONS.TheOrder then
 			return localize("k_ruleset_disabled_the_order_required")
 		end
-		for _, mod in ipairs(SMODS.mods) do
-			if banned_mods[mod.name] then
-				return localize({type = "variable", key="k_ruleset_disabled_banned_mod", vars = {mod.name}})
+		for id, mod in pairs(SMODS.Mods) do
+			for _, v in ipairs(banned_mods) do
+				if mod.can_load and v == id then 
+					return localize({type = "variable", key = "k_ruleset_disabled_banned_mod", vars = {id}})
+				end
 			end
 		end
 		return false

--- a/rulesets/ranked.lua
+++ b/rulesets/ranked.lua
@@ -110,6 +110,11 @@ MP.Ruleset({
 		if not MP.INTEGRATIONS.TheOrder then
 			return localize("k_ruleset_disabled_the_order_required")
 		end
+		for _, mod in ipairs(SMODS.mods) do
+			if banned_mods[mod.name] then
+				return localize({type = "variable", key="k_ruleset_disabled_banned_mod", vars = {mod.name}})
+			end
+		end
 		return false
 	end,
 	force_lobby_options = function(self)


### PR DESCRIPTION
This PR adds a ban list that is manually setup within the code, that prevents certain mods from being used on the ranked ruleset. This should help with people being confused on the ranked ruleset not being the default one for their casual playing, and helps prevent banned mods from being used in ranked.

This list is not all encompassing, but I tried to add a bunch of ones listed as banned in the banned mods list. Any more we can add or a way to automatically keep track of this would be good!