### PR TITLE
Add a join to clipboard button to the main play menu

### DIFF
--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -199,6 +199,7 @@ return {
 		dictionary = {
 			b_singleplayer = "Singleplayer",
 			b_join_lobby = "Join Lobby",
+			b_join_lobby_clipboard = "Join From Clipboard",
 			b_return_lobby = "Return to Lobby",
 			b_reconnect = "Reconnect",
 			b_create_lobby = "Create Lobby",

--- a/ui/main_menu.lua
+++ b/ui/main_menu.lua
@@ -843,12 +843,6 @@ function G.UIDEF.create_UIBox_join_lobby_button()
 								}),
 							},
 						},
-						UIBox_button({
-							label = { localize("k_paste") },
-							colour = G.C.RED,
-							button = "join_from_clipboard",
-							minw = 5,
-						}),
 					},
 				},
 			},
@@ -914,6 +908,12 @@ function G.UIDEF.override_main_menu_play_button()
 					label = { localize("b_join_lobby") },
 					colour = G.C.RED,
 					button = "join_lobby",
+					minw = 5,
+				}) or nil,
+				MP.LOBBY.connected and UIBox_button({
+					label = { localize("b_join_lobby_clipboard") },
+					colour = G.C.BLUE,
+					button = "join_from_clipboard",
 					minw = 5,
 				}) or nil,
 				not MP.LOBBY.connected and UIBox_button({


### PR DESCRIPTION
This adds a join to clipboard button to the main menu, reducing the amount of clicks needed in the play menu to join up to a lobby to 1.