### PR TITLE
Put standard rulesets above competitive

### DIFF
--- a/ui/main_menu.lua
+++ b/ui/main_menu.lua
@@ -186,29 +186,29 @@ end
 
 function G.UIDEF.ruleset_selection_options()
 	MP.LOBBY.fetched_weekly = 'smallworld' -- temp
-	MP.LOBBY.config.ruleset = "ruleset_mp_ranked"
-	MP.LoadReworks("ranked")
+	MP.LOBBY.config.ruleset = "ruleset_mp_blitz"
+	MP.LoadReworks("blitz")
 
 	local default_ruleset_area = UIBox({
-		definition = G.UIDEF.ruleset_info("ranked"),
+		definition = G.UIDEF.ruleset_info("blitz"),
 		config = { align = "cm" }
 	})
 
 	local ruleset_buttons_data = {
-		{
-			name = "k_competitive",
-			buttons = {
-				{ button_id = "ranked_ruleset_button",      button_localize_key = "k_ranked" },
-				{ button_id = "majorleague_ruleset_button", button_localize_key = "k_majorleague" },
-				{ button_id = "minorleague_ruleset_button", button_localize_key = "k_minorleague" },
-			}
-		},
 		{
 			name = "k_standard",
 			buttons = {
 				{ button_id = "blitz_ruleset_button",       button_localize_key = "k_blitz" },
 				{ button_id = "traditional_ruleset_button", button_localize_key = "k_traditional" },
 				{ button_id = "vanilla_ruleset_button",     button_localize_key = "k_vanilla" },
+			}
+		},
+		{
+			name = "k_competitive",
+			buttons = {
+				{ button_id = "ranked_ruleset_button",      button_localize_key = "k_ranked" },
+				{ button_id = "majorleague_ruleset_button", button_localize_key = "k_majorleague" },
+				{ button_id = "minorleague_ruleset_button", button_localize_key = "k_minorleague" },
 			}
 		},
 		{


### PR DESCRIPTION
This is more of a personal opinion, but having ranked be the default ruleset doesn't make much sense to me. This game doesn't entirely revolve around the ranked ruleset for general people using it, and it shouldn't be the first option available, lest it confuses people who just want to play casually or with mods. This moves the standard rulesets up and comp movesets down one (the badlatro and sandbox are still at the bottom) and makes Blitz the default selected one.