### PR TITLE
Add GitHub action for releases

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,49 @@
+# .github/workflows/create_release.yml
+name: Create Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.*"
+
+jobs:
+  release:
+    name: Create draft release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Create release archive
+        run: |
+          REPO_NAME=$(basename $GITHUB_REPOSITORY)
+          VERSION="${{ github.ref_name }}"
+
+          git archive --format=zip --prefix="$REPO_NAME-$VERSION/" HEAD > "$REPO_NAME-$VERSION.zip"
+
+          echo "archive_name=$REPO_NAME-$VERSION.zip" >> $GITHUB_ENV
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: ${{ github.ref_name }}
+          body: |
+            ## Notable Changes
+            TODO
+
+            **Download:** See attached zip file below
+          draft: true
+          prerelease: false
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./${{ env.archive_name }}
+          asset_name: ${{ env.archive_name }}
+          asset_content_type: application/zip


### PR DESCRIPTION
The workflow triggers when you push a version tag (like v1.0.0) to the repository:

1. Tag trigger: Activates on tags matching pattern v[0-9]+.* (e.g., v1.0.0, v2.1.3)
2. Archive creation: Uses git archive to create a ZIP file of the tagged commit with naming format
  RepositoryName-vX.Y.Z.zip
3. Draft release: Creates a hidden draft release on GitHub with:
    - The tag name as the release title
    - A template body with "TODO" placeholder for notable changes
    - The ZIP file attached as a downloadable asset
4. Manual completion: You then edit the draft to add actual release notes and publish when ready

So the process is: tag commit → workflow runs → draft release created → manually edit and publish.

<img width="1201" height="614" alt="image" src="https://github.com/user-attachments/assets/b1c85054-d157-4184-b9b2-71e4097ed88e" />
