### PR TITLE
The Order only for multiplayer games (for now)

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -50,7 +50,7 @@ G.C.MULTIPLAYER = HEX("AC3232")
 MP.SMODS_VERSION = "1.0.0~BETA-0711a"
 
 function MP.should_use_the_order()
-	return MP.LOBBY and MP.LOBBY.config and MP.LOBBY.config.the_order
+	return MP.LOBBY and MP.LOBBY.config and MP.LOBBY.config.the_order and MP.LOBBY.code
 end
 
 function MP.load_mp_file(file)


### PR DESCRIPTION
MP.LOBBY.code is nil in singleplayer and gets set when joining/creating a multiplayer lobby, so let's use that and make singleplayer Orderless!