### PR TITLE
Fix incorrect colon call in reconnect function

### DIFF
--- a/ui/lobby.lua
+++ b/ui/lobby.lua
@@ -536,7 +536,7 @@ end
 
 function G.FUNCS.reconnect(e)
 	MP.ACTIONS.connect()
-	G.FUNCS:exit_overlay_menu()
+	G.FUNCS.exit_overlay_menu()
 end
 
 function MP.update_player_usernames()


### PR DESCRIPTION
Replaced G.FUNCS:exit_overlay_menu() with G.FUNCS.exit_overlay_menu() to prevent a nil call error, since exit_overlay_menu isn’t defined as a method.