### PR TITLE
Add manual deploy workflow for GitHub Actions

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -40,4 +40,4 @@ jobs:
             git pull origin main
 
             # Build and start container
-            docker compose up --build --remove-orphans -d
+            docker compose up --build --force-recreate --remove-orphans -d


### PR DESCRIPTION
This action can only be run by contributors, and will `git pull` then `docker compose up --build --remove-orphans -d` on the server. The key is hidden in Github secrets and can not be viewed by anyone.