### PR TITLE
Fix Small World Michel/Cavendish availability

### DIFF
--- a/rulesets/smallworld.lua
+++ b/rulesets/smallworld.lua
@@ -72,6 +72,12 @@ function MP.ApplyBans()
 		for i, v in ipairs(requires) do
 			if G.GAME.banned_keys[G.P_CENTERS[v].requires[1]] then G.GAME.banned_keys[v] = true end
 		end
+
+		if G.GAME.banned_keys['j_gros_michel'] then
+			G.GAME.banned_keys['j_cavendish'] = true
+		else
+			G.GAME.banned_keys['j_cavendish'] = nil
+		end
 	end
 	return ret
 end


### PR DESCRIPTION
Now j_cavendish will always match j_gros_michel's banned status in small world (if Gros Michel is available, Cavendish is too, if Gros Michel is banned, Cavendish is too).