### PR TITLE
ReworkCenter API refactor

### DIFF
--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -121,7 +121,7 @@ return {
 					"not in a {C:attention}PvP Blind{}",
 				},
 			},
-			j_hanging_chad_mp_standard = {
+			j_mp_hanging_chad_standard = {
 				name = "Hanging Chad",
 				text = {
 					"Retrigger {C:attention}first{} and {C:attention}second{}",

--- a/localization/zh_CN.lua
+++ b/localization/zh_CN.lua
@@ -106,7 +106,7 @@ return {
 					"{X:mult,C:white}X#1#{}倍率",
 				},
 			},
-			j_hanging_chad_mp_standard = {
+			j_mp_hanging_chad_standard = {
 				name = "未断选票",
 				text = {
 					"打出的牌中{C:attention}第一张{}和{C:attention}第二张{}",

--- a/objects/jokers/bloodstone.lua
+++ b/objects/jokers/bloodstone.lua
@@ -1,8 +1,6 @@
 -- this is kinda strange but we can just override the logic for pvp only rather than re-implementing it again, bc if we don't return anything, it'll run the normal logic
 
-MP.ReworkCenter({
-	key = "j_bloodstone",
-	ruleset = MP.UTILS.get_standard_rulesets({ "minorleague" }),
+MP.ReworkCenter("j_bloodstone", MP.UTILS.get_standard_rulesets({ "minorleague" }), nil, {
 	silent = true,
 	calculate = function(self, card, context)
 		if MP.is_pvp_boss() and MP.should_use_the_order() then

--- a/objects/jokers/hanging_chad.lua
+++ b/objects/jokers/hanging_chad.lua
@@ -1,10 +1,8 @@
-MP.ReworkCenter({
-	key = "j_hanging_chad",
-	ruleset = MP.UTILS.get_standard_rulesets(),
+MP.ReworkCenter("j_hanging_chad", MP.UTILS.get_standard_rulesets(), "j_mp_hanging_chad_standard", {
 	config = { extra = 1 },
 	loc_vars = function(self, info_queue, card)
 		return {
-			key = self.key .. "_mp_standard",
+			-- key = self.key .. "_mp_standard",
 			vars = { card.ability.extra },
 		}
 	end,


### PR DESCRIPTION
Two commits here. 

--

The first one fixes `loc_vars` not working on vanilla centers. Vanilla jokers don't have a generate_ui function so SMODS never calls their loc_vars. We were working around this with take_ownership jank (see multiplayer `hanging_chad`).

Now ReworkCenter auto-injects `generate_ui = SMODS.Center.generate_ui` when you add `loc_vars` to a vanilla center which removes the need for take_ownership hacks.

---

The second commit builds on the previous fix. The old API had key and ruleset buried in the args table, and if you wanted alternate localization text, you had to return { key = "...", vars = {...} } from inside loc_vars - magic hidden in the function body.

New signature: `MP.ReworkCenter(key, ruleset, loc_key, args)`

Now loc_key is explicit, just pass the alternate localization key (or `nil` to keep original) and the function handles injecting it into loc_vars for you.