### PR TITLE
Track joker stats for multiplayer wins

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -11,4 +11,6 @@ return {
 	},
 	["unlocked"] = true,
 	["preview"] = {},
+	["joker_stats"] = {},
+	["match_history"] = {},
 }

--- a/lib/joker_stats.lua
+++ b/lib/joker_stats.lua
@@ -1,0 +1,44 @@
+MP.STATS = {}
+
+function MP.STATS.get_player_joker_keys()
+	local keys = {}
+	if not G.jokers or not G.jokers.cards then return keys end
+	for i = 1, #G.jokers.cards do
+		local card = G.jokers.cards[i]
+		if card.config and card.config.center and card.config.center.key then
+			if not card.edition or card.edition.type ~= "mp_phantom" then table.insert(keys, card.config.center.key) end
+		end
+	end
+	return keys
+end
+
+function MP.STATS.record_match(won)
+	local config = SMODS.Mods["Multiplayer"].config
+	config.joker_stats = config.joker_stats or {}
+	config.match_history = config.match_history or {}
+
+	local joker_keys = MP.STATS.get_player_joker_keys()
+
+	local entry = {
+		won = won,
+		joker_keys = joker_keys,
+		gamemode = MP.LOBBY.config.gamemode,
+		ruleset = MP.LOBBY.config.ruleset,
+		timestamp = os.time(),
+		ante_reached = G.GAME.round_resets and G.GAME.round_resets.ante or 1,
+	}
+	table.insert(config.match_history, entry)
+
+	if won then
+		for _, key in ipairs(joker_keys) do
+			config.joker_stats[key] = (config.joker_stats[key] or 0) + 1
+		end
+	end
+
+	SMODS.save_mod_config(SMODS.Mods["Multiplayer"])
+end
+
+function MP.STATS.get_joker_wins(joker_key)
+	local config = SMODS.Mods["Multiplayer"].config
+	return config.joker_stats and config.joker_stats[joker_key] or 0
+end

--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -253,6 +253,7 @@ local function action_win_game()
 	MP.end_game_jokers_received = false
 	MP.nemesis_deck_received = false
 	MP.GAME.won = true
+	MP.STATS.record_match(true)
 	win_game()
 end
 
@@ -261,6 +262,7 @@ local function action_lose_game()
 	MP.nemesis_deck_string = ""
 	MP.end_game_jokers_received = false
 	MP.nemesis_deck_received = false
+	MP.STATS.record_match(false)
 	G.STATE_COMPLETE = false
 	G.STATE = G.STATES.GAME_OVER
 end


### PR DESCRIPTION
Record match results and per-joker win counts to config. Stores joker_keys, win/loss, gamemode, ruleset, timestamp, ante_reached. Groundwork for joker stickers feature.