### PR TITLE
feat(ranked): gate ranked on Lovely version

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -67,6 +67,7 @@ MP.EXPERIMENTAL = {
 G.C.MULTIPLAYER = HEX("AC3232")
 
 MP.SMODS_VERSION = "1.0.0~BETA-1224a"
+MP.REQUIRED_LOVELY_VERSION = "0.9"
 
 function MP.should_use_the_order()
 	return MP.LOBBY and MP.LOBBY.config and MP.LOBBY.config.the_order and MP.LOBBY.code

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -918,6 +918,7 @@ return {
 			k_reworked_objs = "Reworked #1#",
 			k_no_reworked_objs = "No Reworked #1#",
 			k_ruleset_disabled_smods_version = "SMODS Version #1# Required",
+			k_ruleset_disabled_lovely_version = "Lovely #1# Required",
 			k_failed_to_join_lobby = "Failed to join lobby: #1#",
 			k_ante_number = "Ante #1#",
 			k_ante_range = "Ante #1#-#2#", -- For example, "Ante 1-2"

--- a/rulesets/ranked.lua
+++ b/rulesets/ranked.lua
@@ -49,6 +49,14 @@ MP.Ruleset({
 		if SMODS.version ~= MP.SMODS_VERSION then
 			return localize({ type = "variable", key = "k_ruleset_disabled_smods_version", vars = { MP.SMODS_VERSION } })
 		end
+		local lovely_ver = lovely and lovely.version or ""
+		if not lovely_ver:match("^" .. MP.REQUIRED_LOVELY_VERSION:gsub("%.", "%%.")) then
+			return localize({
+				type = "variable",
+				key = "k_ruleset_disabled_lovely_version",
+				vars = { MP.REQUIRED_LOVELY_VERSION },
+			})
+		end
 		return false
 	end,
 	force_lobby_options = function(self)


### PR DESCRIPTION
### Why

Ranked already gates on a specific SMODS version, but Lovely (the binary
patcher) can drift independently. A mismatched Lovely version produces subtle
desyncs that surface mid-match with no useful error. Players get confused;
bug reports get filed; nobody learns anything.

### What this does

Adds a `MP.REQUIRED_LOVELY_VERSION` constant (`"0.9"`) and a prefix-match
check in the ranked ruleset's `is_disabled` callback, parallel to the existing
SMODS version gate. If the player's Lovely version doesn't match, ranked
displays a clear "Lovely X.Y Required" message instead of letting them queue.

Three files, ten lines:
- **core.lua** — new `MP.REQUIRED_LOVELY_VERSION` constant
- **rulesets/ranked.lua** — version check in `is_disabled`
- **localization/en-us.lua** — `k_ruleset_disabled_lovely_version` string

### What it doesn't do

Check Lovely version for non-ranked rulesets, enforce a patch-level match
(prefix match only — `0.9` accepts `0.9.1`, `0.9.2`, etc.), or auto-update
anything.

### Test plan

- [ ] Launch with Lovely 0.9.x — ranked ruleset is selectable
- [ ] Launch with Lovely 0.8.x (or without Lovely) — ranked shows "Lovely 0.9 Required" and is disabled
- [ ] Other rulesets remain unaffected regardless of Lovely version