### PR TITLE
fix(glass): migrate ReworkCenter calls to opts-table API

### DIFF
--- a/objects/enhancements/mp_glass.lua
+++ b/objects/enhancements/mp_glass.lua
@@ -1,7 +1,9 @@
-MP.ReworkCenter("m_glass", MP.UTILS.get_standard_rulesets(), nil, {
+MP.ReworkCenter("m_glass", {
+	rulesets = MP.UTILS.get_standard_rulesets(),
 	config = { Xmult = 1.5, extra = 4 },
 })
 
-MP.ReworkCenter("m_glass", "sandbox", nil, {
+MP.ReworkCenter("m_glass", {
+	rulesets = "sandbox",
 	config = { Xmult = 1.5, extra = 3 },
 })


### PR DESCRIPTION
## Why

#356 refactored ReworkCenter from positional args (key, rulesets, loc_key,
opts) to a single opts-table (key, opts). Glass was still calling the old
signature, which meant the function interpreted a rulesets array as the opts
table. Rulesets silently ignored, config never applied. Glass cards were
running vanilla stats in ranked.

## What this does

Rewrites both mp_glass.lua calls to pass rulesets and config inside the opts
table where the new API expects them. No behavior change beyond "actually
working."