### PR TITLE
Track jokers / improve telemetry

### DIFF
--- a/lib/joker_stats.lua
+++ b/lib/joker_stats.lua
@@ -78,7 +78,7 @@ end
 --- Call when a joker is removed from the player's deck.
 --- Matches by card object reference first, falls back to key match.
 --- @param card table       -- the Card object being removed
---- @param reason string    -- "sold", "destroyed", "perishable", "traded"
+--- @param reason string    -- "sold", "destroyed", "perishable"
 function MP.STATS.on_joker_removed(card, reason)
 	if not MP.LOBBY.code then return end
 	-- First try exact card reference match

--- a/lib/joker_stats.lua
+++ b/lib/joker_stats.lua
@@ -36,9 +36,83 @@ function MP.STATS.record_match(won)
 	end
 
 	SMODS.save_mod_config(SMODS.Mods["Multiplayer"])
+
+	-- Send telemetry to server
+	local joker_report = MP.STATS.build_joker_report(won)
+	if #joker_report > 0 then
+		MP.ACTIONS.match_joker_report(won, joker_report)
+	end
+	MP.STATS.reset_lifecycle()
 end
 
 function MP.STATS.get_joker_wins(joker_key)
 	local config = SMODS.Mods["Multiplayer"].config
 	return config.joker_stats and config.joker_stats[joker_key] or 0
+end
+
+-- Joker lifecycle tracking (reset each match)
+MP.STATS.joker_lifecycle = {}
+
+--- Call when a joker is added to the player's deck.
+--- @param key string       -- e.g. "j_pizza", "j_mp_speedrun"
+--- @param edition string   -- e.g. "polychrome", "foil", "none"
+--- @param seal string      -- e.g. "eternal", "perishable", "none"
+--- @param cost number      -- gold spent (0 if free)
+--- @param source string    -- "shop", "booster", "tag", "other"
+function MP.STATS.on_joker_acquired(key, edition, seal, cost, source)
+	if not MP.LOBBY.code then return end -- only track in multiplayer
+	table.insert(MP.STATS.joker_lifecycle, {
+		key = key,
+		edition = edition or "none",
+		seal = seal or "none",
+		cost = cost or 0,
+		source = source or "other",
+		ante_acquired = G.GAME.round_resets and G.GAME.round_resets.ante or 1,
+		ante_removed = nil,
+		removal_reason = nil,
+	})
+end
+
+--- Call when a joker is removed from the player's deck.
+--- Finds the most recent un-removed entry for this key.
+--- @param key string
+--- @param reason string -- "sold", "destroyed", "perishable", "traded"
+function MP.STATS.on_joker_removed(key, reason)
+	if not MP.LOBBY.code then return end
+	-- Walk backwards to find the most recent un-removed entry
+	for i = #MP.STATS.joker_lifecycle, 1, -1 do
+		local entry = MP.STATS.joker_lifecycle[i]
+		if entry.key == key and entry.ante_removed == nil then
+			entry.ante_removed = G.GAME.round_resets and G.GAME.round_resets.ante or 1
+			entry.removal_reason = reason
+			break
+		end
+	end
+end
+
+--- Build the match joker report payload.
+--- Called from record_match() after the existing local-save logic.
+function MP.STATS.build_joker_report(won)
+	local report = {}
+	local final_ante = G.GAME.round_resets and G.GAME.round_resets.ante or 1
+	for _, entry in ipairs(MP.STATS.joker_lifecycle) do
+		table.insert(report, {
+			key = entry.key,
+			edition = entry.edition,
+			seal = entry.seal,
+			cost = entry.cost,
+			source = entry.source,
+			ante_acquired = entry.ante_acquired,
+			ante_removed = entry.ante_removed,         -- nil if held to end
+			removal_reason = entry.removal_reason,     -- nil if held to end
+			held_at_end = entry.ante_removed == nil,
+			hold_duration_antes = (entry.ante_removed or final_ante) - entry.ante_acquired,
+		})
+	end
+	return report
+end
+
+--- Reset lifecycle tracking for a new match.
+function MP.STATS.reset_lifecycle()
+	MP.STATS.joker_lifecycle = {}
 end

--- a/lib/joker_stats.lua
+++ b/lib/joker_stats.lua
@@ -54,14 +54,16 @@ end
 MP.STATS.joker_lifecycle = {}
 
 --- Call when a joker is added to the player's deck.
+--- @param card table       -- the Card object reference (used to match on removal)
 --- @param key string       -- e.g. "j_pizza", "j_mp_speedrun"
 --- @param edition string   -- e.g. "polychrome", "foil", "none"
 --- @param seal string      -- e.g. "eternal", "perishable", "none"
 --- @param cost number      -- gold spent (0 if free)
 --- @param source string    -- "shop", "booster", "tag", "other"
-function MP.STATS.on_joker_acquired(key, edition, seal, cost, source)
+function MP.STATS.on_joker_acquired(card, key, edition, seal, cost, source)
 	if not MP.LOBBY.code then return end -- only track in multiplayer
 	table.insert(MP.STATS.joker_lifecycle, {
+		card_ref = card,
 		key = key,
 		edition = edition or "none",
 		seal = seal or "none",
@@ -74,18 +76,30 @@ function MP.STATS.on_joker_acquired(key, edition, seal, cost, source)
 end
 
 --- Call when a joker is removed from the player's deck.
---- Finds the most recent un-removed entry for this key.
---- @param key string
---- @param reason string -- "sold", "destroyed", "perishable", "traded"
-function MP.STATS.on_joker_removed(key, reason)
+--- Matches by card object reference first, falls back to key match.
+--- @param card table       -- the Card object being removed
+--- @param reason string    -- "sold", "destroyed", "perishable", "traded"
+function MP.STATS.on_joker_removed(card, reason)
 	if not MP.LOBBY.code then return end
-	-- Walk backwards to find the most recent un-removed entry
+	-- First try exact card reference match
 	for i = #MP.STATS.joker_lifecycle, 1, -1 do
 		local entry = MP.STATS.joker_lifecycle[i]
-		if entry.key == key and entry.ante_removed == nil then
+		if entry.card_ref == card and entry.ante_removed == nil then
 			entry.ante_removed = G.GAME.round_resets and G.GAME.round_resets.ante or 1
 			entry.removal_reason = reason
-			break
+			return
+		end
+	end
+	-- Fallback: match by key (for cases where card ref isn't available)
+	local key = card.config and card.config.center and card.config.center.key
+	if key then
+		for i = #MP.STATS.joker_lifecycle, 1, -1 do
+			local entry = MP.STATS.joker_lifecycle[i]
+			if entry.key == key and entry.ante_removed == nil then
+				entry.ante_removed = G.GAME.round_resets and G.GAME.round_resets.ante or 1
+				entry.removal_reason = reason
+				return
+			end
 		end
 	end
 end

--- a/lib/joker_stats.lua
+++ b/lib/joker_stats.lua
@@ -60,7 +60,7 @@ MP.STATS.joker_lifecycle = {}
 --- @param seal string      -- e.g. "eternal", "perishable", "none"
 --- @param cost number      -- gold spent (0 if free)
 --- @param source string    -- "shop", "booster", "tag", "other"
-function MP.STATS.on_joker_acquired(card, key, edition, seal, cost, source)
+function MP.STATS.on_joker_acquired(card, key, edition, cost, source)
 	if not MP.LOBBY.code then return end -- only track in multiplayer
 	table.insert(MP.STATS.joker_lifecycle, {
 		card_ref = card,
@@ -113,7 +113,6 @@ function MP.STATS.build_joker_report(won)
 		table.insert(report, {
 			key = entry.key,
 			edition = entry.edition,
-			seal = entry.seal,
 			cost = entry.cost,
 			source = entry.source,
 			ante_acquired = entry.ante_acquired,

--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -112,6 +112,7 @@ end
 ---@param stake_str string
 local function action_start_game(seed, stake_str)
 	MP.reset_game_states()
+	MP.STATS.reset_lifecycle()
 	local stake = tonumber(stake_str)
 	MP.ACTIONS.set_ante(0)
 	if not MP.LOBBY.config.different_seeds and MP.LOBBY.config.custom_seed ~= "random" then
@@ -932,6 +933,19 @@ function MP.ACTIONS.send_game_stats()
 		action = "sendGameStats",
 	})
 	action_send_game_stats()
+end
+
+function MP.ACTIONS.match_joker_report(won, joker_report)
+	Client.send({
+		action = "matchJokerReport",
+		won = won,
+		stake = MP.LOBBY.config.stake or 1,
+		deck = MP.LOBBY.config.back or "Red Deck",
+		gamemode = MP.LOBBY.config.gamemode or "gamemode_mp_attrition",
+		ruleset = MP.LOBBY.config.ruleset or "ruleset_mp_blitz",
+		ante_reached = G.GAME.round_resets and G.GAME.round_resets.ante or 1,
+		jokers = joker_report,
+	})
 end
 
 function MP.ACTIONS.request_nemesis_stats()

--- a/overrides/game.lua
+++ b/overrides/game.lua
@@ -47,8 +47,7 @@ function G.FUNCS.buy_from_shop(e)
 		if c1.config and c1.config.center and c1.config.center.set == "Joker" then
 			local key = c1.config.center.key
 			local edition = (c1.edition and c1.edition.type) or "none"
-			local seal = c1.seal or "none"
-			MP.STATS.on_joker_acquired(c1, key, edition, seal, c1.cost, "shop")
+			MP.STATS.on_joker_acquired(c1, key, edition, c1.cost, "shop")
 		end
 	end
 	return buy_from_shop_ref(e)

--- a/overrides/game.lua
+++ b/overrides/game.lua
@@ -13,8 +13,7 @@ function Card:sell_card()
 		)
 		-- Track joker removals for telemetry
 		if self.config and self.config.center and self.config.center.set == "Joker" then
-			local key = self.config.center.key
-			MP.STATS.on_joker_removed(key, "sold")
+			MP.STATS.on_joker_removed(self, "sold")
 		end
 	end
 	return sell_card_ref(self)
@@ -49,7 +48,7 @@ function G.FUNCS.buy_from_shop(e)
 			local key = c1.config.center.key
 			local edition = (c1.edition and c1.edition.type) or "none"
 			local seal = c1.seal or "none"
-			MP.STATS.on_joker_acquired(key, edition, seal, c1.cost, "shop")
+			MP.STATS.on_joker_acquired(c1, key, edition, seal, c1.cost, "shop")
 		end
 	end
 	return buy_from_shop_ref(e)
@@ -60,20 +59,20 @@ local add_to_deck_ref = Card.add_to_deck
 function Card:add_to_deck(from_debuff)
 	if self.config and self.config.center and self.config.center.set == "Joker" then
 		if not (self.edition and self.edition.type == "mp_phantom") then
-			local key = self.config.center.key
-			-- Check if this joker was already tracked via shop purchase
+			-- Check if this exact card was already tracked via shop purchase
 			local already_tracked = false
 			for i = #MP.STATS.joker_lifecycle, 1, -1 do
 				local entry = MP.STATS.joker_lifecycle[i]
-				if entry.key == key and entry.ante_removed == nil and entry.source == "shop" then
+				if entry.card_ref == self and entry.ante_removed == nil then
 					already_tracked = true
 					break
 				end
 			end
 			if not already_tracked then
+				local key = self.config.center.key
 				local edition = (self.edition and self.edition.type) or "none"
 				local seal = self.seal or "none"
-				MP.STATS.on_joker_acquired(key, edition, seal, 0, "other")
+				MP.STATS.on_joker_acquired(self, key, edition, seal, 0, "other")
 			end
 		end
 	end

--- a/overrides/game.lua
+++ b/overrides/game.lua
@@ -54,31 +54,6 @@ function G.FUNCS.buy_from_shop(e)
 	return buy_from_shop_ref(e)
 end
 
--- Track joker acquisitions from non-shop sources (boosters, tags, etc.)
-local add_to_deck_ref = Card.add_to_deck
-function Card:add_to_deck(from_debuff)
-	if self.config and self.config.center and self.config.center.set == "Joker" then
-		if not (self.edition and self.edition.type == "mp_phantom") then
-			-- Check if this exact card was already tracked via shop purchase
-			local already_tracked = false
-			for i = #MP.STATS.joker_lifecycle, 1, -1 do
-				local entry = MP.STATS.joker_lifecycle[i]
-				if entry.card_ref == self and entry.ante_removed == nil then
-					already_tracked = true
-					break
-				end
-			end
-			if not already_tracked then
-				local key = self.config.center.key
-				local edition = (self.edition and self.edition.type) or "none"
-				local seal = self.seal or "none"
-				MP.STATS.on_joker_acquired(self, key, edition, seal, 0, "other")
-			end
-		end
-	end
-	return add_to_deck_ref(self, from_debuff)
-end
-
 local use_card_ref = G.FUNCS.use_card
 function G.FUNCS.use_card(e, mute, nosave)
 	if e.config and e.config.ref_table and e.config.ref_table.ability and e.config.ref_table.ability.name then


### PR DESCRIPTION
This PR introduces some new log events, intended to track jokers being bought/sold during a match, and for how long. 

----

How it appears in the log file 

`
INFO - [G] 2026-03-01 09:33:49 :: TRACE :: MULTIPLAYER :: Client sent message: {"jokers":[{"cost":4,"ante_acquired":1,"key":"j_zany","edition":"none","seal":"none","held_at_end":true,"hold_duration_antes":1,"source":"shop"},{"cost":5,"ante_acquired":1,"ante_removed":1,"key":"j_wrathful_joker","edition":"none","seal":"none","held_at_end":false,"hold_duration_antes":0,"source":"shop","removal_reason":"sold"},{"cost":7,"ante_acquired":2,"ante_removed":2,"key":"j_mp_bloodstone","edition":"none","seal":"none","held_at_end":false,"hold_duration_antes":0,"source":"shop","removal_reason":"sold"}],"ruleset":"ruleset_mp_blitz","ante_reached":2,"won":false,"gamemode":"gamemode_mp_attrition","deck":"Red Deck","stake":1,"action":"matchJokerReport"}
`

---

I'm following this up with a PR to accumulate and store this data in the API server, however this PR works in isolation as it has no affects on behaviour. 

I've tested it locally with no issues. 