### PR TITLE
Update JokerDisplay compatability

### DIFF
--- a/Multiplayer.json
+++ b/Multiplayer.json
@@ -22,6 +22,7 @@
     "SystemClock (<<1.6.3)",
     "Cryptid (<<0.5.4)",
     "Talisman (<=2.0.2)",
-    "VirtualizedMultiplayer"
+    "VirtualizedMultiplayer",
+    "JokerDisplay (<<1.9.6)"
   ]
 }


### PR DESCRIPTION
I'm going to set a conflict for all JokerDisplay versions older than the latest release, this is the only way we can actually fix seltzer crashing for people that won't bother to update the JokerDisplay