### PR TITLE
Fix connection message position when resizing the window

### DIFF
--- a/ui/lobby/lobby.lua
+++ b/ui/lobby/lobby.lua
@@ -501,8 +501,8 @@ end
 local gameMainMenuRef = Game.main_menu
 ---@diagnostic disable-next-line: duplicate-set-field
 function Game:main_menu(change_context)
-	MP.UI.update_connection_status()
 	gameMainMenuRef(self, change_context)
+	MP.UI.update_connection_status()
 end
 
 function G.FUNCS.copy_to_clipboard(e)


### PR DESCRIPTION
The "Connected to Service" message would become mispositioned if the window got resized:

<img width="1519" height="790" alt="Screenshot 2026-03-10 205156" src="https://github.com/user-attachments/assets/168da891-dacd-4f6b-94e4-0b2987681148" />

This simple change fixes this:

<img width="1572" height="889" alt="Screenshot 2026-03-10 205355" src="https://github.com/user-attachments/assets/08bf258d-1827-41c2-a4fe-4ab681ad5994" />
