### PR TITLE
Fix Pizza + Blueprint interaction

### DIFF
--- a/objects/jokers/pizza.lua
+++ b/objects/jokers/pizza.lua
@@ -12,7 +12,7 @@ SMODS.Joker({
 	cost = 4,
 	unlocked = true,
 	discovered = true,
-	blueprint_compat = true,
+	blueprint_compat = false,
 	eternal_compat = false,
 	perishable_compat = true,
 	config = { extra = { discards = 2, discards_nemesis = 1 } },
@@ -34,15 +34,13 @@ SMODS.Joker({
 		end
 	end,
 	calculate = function(self, card, context)
-		if context.mp_end_of_pvp and (not card.edition or card.edition.type ~= "mp_phantom") then
-			-- do things
+		if context.mp_end_of_pvp and not context.blueprint and (not card.edition or card.edition.type ~= "mp_phantom") then
 			MP.GAME.pizza_discards = MP.GAME.pizza_discards + card.ability.extra.discards
 			G.GAME.round_resets.discards = G.GAME.round_resets.discards + card.ability.extra.discards
 			ease_discard(card.ability.extra.discards)
 			MP.ACTIONS.eat_pizza(card.ability.extra.discards_nemesis)
-			local _card = context.blueprint_card or card
-			_card:remove_from_deck()
-			_card:start_dissolve({ G.C.RED }, nil, 1.6)
+			card:remove_from_deck()
+			card:start_dissolve({ G.C.RED }, nil, 1.6)
 			return {
 				message = localize("k_eaten_ex"),
 				colour = G.C.RED,


### PR DESCRIPTION
Blueprint copying Pizza dissolved the Blueprint instead of Pizza, and doubled the discard/eat effects.

Set `blueprint_compat = false` and added a `context.blueprint` guard so the effect only fires from the actual Pizza card.