### PR TITLE
Fix hand check to not break when the hands remaining is between 0 and 1

### DIFF
--- a/rulesets/speedlatro.lua
+++ b/rulesets/speedlatro.lua
@@ -69,7 +69,7 @@ function Game:update(dt)
 		end
 		-- holy fucking conditional
 		if not (G.STATE == G.STATES.HAND_PLAYED 
-		and G.GAME.current_round.hands_left < 1 
+		and G.GAME.current_round.hands_left <= 0 
 		and G.STATE_COMPLETE 
 		and MP.LOBBY.connected 
 		and MP.LOBBY.code 

--- a/ui/game/game_state.lua
+++ b/ui/game/game_state.lua
@@ -203,7 +203,7 @@ function Game:update_hand_played(dt)
 			func = function()
 				MP.ACTIONS.play_hand(G.GAME.chips, G.GAME.current_round.hands_left)
 				-- For now, never advance to next round
-				if G.GAME.current_round.hands_left < 1 then
+				if G.GAME.current_round.hands_left <= 0 then
 					attention_text({
 						scale = 0.8,
 						text = localize("k_wait_enemy"),


### PR DESCRIPTION
This fixes a race condition that freezes up the game when playing with mods that make it possible to get something like +0.5 hands.