### PR TITLE
Add mod to title-screen blacklist + asteroid safeguard

### DIFF
--- a/ui/game/functions.lua
+++ b/ui/game/functions.lua
@@ -368,9 +368,7 @@ function MP.UI.show_asteroid_hand_level_up()
 
 	for k, v in pairs(G.GAME.hands) do
 		if SMODS.is_poker_hand_visible(k) then
-			if 
-				hand_priority[k] == nil
-			then
+			if hand_priority[k] == nil then
 				hand_priority[k] = 0 -- Safeguard for modded hands
 			end
 			if

--- a/ui/game/functions.lua
+++ b/ui/game/functions.lua
@@ -368,6 +368,11 @@ function MP.UI.show_asteroid_hand_level_up()
 
 	for k, v in pairs(G.GAME.hands) do
 		if SMODS.is_poker_hand_visible(k) then
+			if 
+				hand_priority[k] == nil
+			then
+				hand_priority[k] = 0 -- Safeguard for modded hands
+			end
 			if
 				to_big(v.level) > to_big(max_level)
 				or (to_big(v.level) == to_big(max_level) and hand_priority[k] < hand_priority[hand_type])

--- a/ui/main_menu/title_card.lua
+++ b/ui/main_menu/title_card.lua
@@ -59,7 +59,7 @@ end
 local function has_mod_manipulating_title_card()
 	-- maintain a list of all mods that affect the title card here
 	-- (must use the mod's id, not its name)
-	local modlist = { "BUMod", "Cryptid", "Talisman", "Pokermon" "FGCBalatro" }
+	local modlist = { "BUMod", "Cryptid", "Talisman", "Pokermon", "FGCBalatro" }
 	for _, modname in ipairs(modlist) do
 		if SMODS.Mods[modname] and SMODS.Mods[modname].can_load then return true end
 	end

--- a/ui/main_menu/title_card.lua
+++ b/ui/main_menu/title_card.lua
@@ -59,7 +59,7 @@ end
 local function has_mod_manipulating_title_card()
 	-- maintain a list of all mods that affect the title card here
 	-- (must use the mod's id, not its name)
-	local modlist = { "BUMod", "Cryptid", "Talisman", "Pokermon" }
+	local modlist = { "BUMod", "Cryptid", "Talisman", "Pokermon" "FGCBalatro" }
 	for _, modname in ipairs(modlist) do
 		if SMODS.Mods[modname] and SMODS.Mods[modname].can_load then return true end
 	end


### PR DESCRIPTION
This adds 'FGCBalatro' (https://github.com/Noah-Bunis/FGCBalatro) to the blacklist for mods that edit the title screen.
Additionally, this adds an safeguard for asteroid such that modded hands do not crash the game when asteroid is played.
(ex. Yahimods jerma985, FGCBalatros Half Circle)