### PR TITLE
feat(logging): log timestamp with timezone on game start

### DIFF
--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -228,6 +228,10 @@ end
 ---@param seed string
 ---@param stake_str string
 local function action_start_game(seed, stake_str)
+	sendDebugMessage(
+		string.format("Game starting — %s", os.date("%Y-%m-%dT%H:%M:%S%z")),
+		"MULTIPLAYER"
+	)
 	MP.reset_game_states()
 	local stake = tonumber(stake_str)
 	MP.ACTIONS.set_ante(0)


### PR DESCRIPTION
### Why

Practice mode log parsing needs to resolve timestamps to figure out when games actually started. Without a timezone offset, that resolution is ambiguous.

### What this does

Adds a single `sendDebugMessage` at the top of `action_start_game` in `networking/action_handlers.lua`. Emits an ISO 8601 timestamp with UTC offset: `Game starting — 2026-04-06T14:25:00-0400`.

### Test plan

- [ ] Start a multiplayer game, check the LÖVE console for the `MULTIPLAYER` debug line with a timestamp and timezone offset

🤖 Generated with [Claude Code](https://claude.com/claude-code)