### PR TITLE
Fix sandbox Castle chip display and Ectoplasm crash

### DIFF
--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -254,7 +254,7 @@ return {
 			j_mp_castle_sandbox = {
 				name = "Castle",
 				text = {
-					"This Joker gains {C:chips}#3{} Chips",
+					"This Joker gains {C:chips}+#3#{} Chips",
 					"per discarded {V:1}#1#{}",
 					"Suit locked on purchase",
 					"{C:inactive}(Currently {C:chips}+#2#{C:inactive} Chips)",

--- a/objects/consumables/sandbox/ectoplasm.lua
+++ b/objects/consumables/sandbox/ectoplasm.lua
@@ -30,7 +30,7 @@ SMODS.Consumable({
 				end
 
 				-- positive effect: negative joker
-				if #editionless_jokers then
+				if #editionless_jokers > 0 then
 					local eligible_card = pseudorandom_element(editionless_jokers, "ectoplasm")
 					eligible_card:set_edition({ negative = true })
 				end
@@ -41,9 +41,7 @@ SMODS.Consumable({
 		}))
 	end,
 	can_use = function(self, card)
-		return true
-		-- return G.GAME.round_resets.hands >= 1 and G.GAME.round_resets.discards >= 0
-		-- return next(SMODS.Edition:get_edition_cards(G.jokers, true))
+		return next(SMODS.Edition:get_edition_cards(G.jokers, true))
 	end,
 	-- draw = function(self, card, layer)
 	-- 	-- This is for the Spectral shader. You don't need this with `set = "Spectral"`


### PR DESCRIPTION
## Summary
- **Castle**: Fix broken loc var `#3` → `+#3#` so chip gain amount renders
- **Ectoplasm**: Gate `can_use` on editionless jokers existing; fix always-truthy `#table` guard in `use`