### PR TITLE
No-Animation timer base implementation; Optimizing Fantom's preview

### DIFF
--- a/compatibility/Preview/CorePreview.lua
+++ b/compatibility/Preview/CorePreview.lua
@@ -1,5 +1,10 @@
--- The functions responsible for running the simulation at appropriate times;
--- ie. whenever the player modifies card selection or card order.
+-- The functions responsible for running the simulation.
+-- Previously it was doing it after every game state change, which maybe makes sense on SP.
+-- But, since it's Multiplayer-specific version, it shows score only after "Calculate" button press and reset after state change.
+
+function FN.PRE.cleanup()
+    return { score = { min = 0, exact = 0, max = 0 }, dollars = { min = 0, exact = 0, max = 0 }, empty = true }
+end
 
 function FN.PRE.simulate()
 	-- Guard against simulating in redundant places:
@@ -9,7 +14,7 @@ function FN.PRE.simulate()
 	if
 		not (G.STATE == G.STATES.SELECTING_HAND or G.STATE == G.STATES.DRAW_TO_HAND or G.STATE == G.STATES.PLAY_TAROT)
 	then
-		return { score = { min = 0, exact = 0, max = 0 }, dollars = { min = 0, exact = 0, max = 0 } }
+		return FN.PRE.cleanup()
 	end
 
 	if G.SETTINGS.FN.hide_face_down then
@@ -28,55 +33,43 @@ end
 
 -- SIMULATION UPDATE ADVICE:
 
-function FN.PRE.add_update_event(trigger)
-	function sim_func()
-		FN.PRE.data = FN.PRE.simulate()
-		return true
-	end
-	if FN.PRE.enabled() then
-		G.E_MANAGER:add_event(Event({ trigger = trigger, blockable = false, blocking = false, func = sim_func }))
-	end
-end
-
 -- Update simulation after a consumable (eg. Tarot, Planet) is used:
 local orig_use = Card.use_consumeable
 function Card:use_consumeable(area, copier)
 	orig_use(self, area, copier)
-	if not MP.INTEGRATIONS.Preview then return end
-	FN.PRE.add_update_event("immediate")
+	FN.PRE.stop_current_coroutine()
 end
 
 -- Update simulation after card selection changed:
 local orig_hl = CardArea.parse_highlighted
 function CardArea:parse_highlighted()
 	orig_hl(self)
-	if not MP.INTEGRATIONS.Preview then return end
-
-	if not FN.PRE.lock_updates and FN.PRE.show_preview then FN.PRE.show_preview = false end
-	FN.PRE.add_update_event("immediate")
+	FN.PRE.stop_current_coroutine(true)
 end
 
--- Update simulation after joker sold:
+-- Update simulation after card in hand/consumeables/joker slots are removed:
 local orig_card_remove = Card.remove_from_area
 function Card:remove_from_area()
 	orig_card_remove(self)
-	if not MP.INTEGRATIONS.Preview then return end
-
-	if self.config.type == "joker" then FN.PRE.add_update_event("immediate") end
+    if self.area and G.STATE ~= G.STATES.HAND_PLAYED then        
+        if not (self == G.joker or self == G.consumeables or self == G.hand) then return end
+        FN.PRE.stop_current_coroutine()
+    end
 end
 
 -- Update simulation after joker reordering:
 local orig_update = CardArea.update
 function CardArea:update(dt)
 	orig_update(self, dt)
-	if not MP.INTEGRATIONS.Preview then return end
-
 	FN.PRE.update_on_card_order_change(self)
 end
 
 function FN.PRE.update_on_card_order_change(cardarea)
+    if not MP.INTEGRATIONS.Preview then return end
+    if not (cardarea == G.joker or cardarea == G.hand) then return end
 	if
-		#cardarea.cards == 0
+        not cardarea.cards
+		or #cardarea.cards == 0
 		or not (
 			G.STATE == G.STATES.SELECTING_HAND
 			or G.STATE == G.STATES.DRAW_TO_HAND
@@ -116,35 +109,30 @@ function FN.PRE.update_on_card_order_change(cardarea)
 		elseif cardarea.config.type == "hand" then
 			FN.PRE.hand_order = prev_order
 		end
-		if FN.PRE.show_preview and not FN.PRE.lock_updates then FN.PRE.show_preview = false end
-		FN.PRE.add_update_event("immediate")
+		FN.PRE.stop_current_coroutine(true)
 	end
 end
 
 -- SIMULATION RESET ADVICE:
 
-function FN.PRE.add_reset_event(trigger)
-	function reset_func()
-		FN.PRE.data = { score = { min = 0, exact = 0, max = 0 }, dollars = { min = 0, exact = 0, max = 0 } }
-		return true
-	end
-	if FN.PRE.enabled() then G.E_MANAGER:add_event(Event({ trigger = trigger, func = reset_func })) end
-end
-
 local orig_eval = G.FUNCS.evaluate_play
 function G.FUNCS.evaluate_play(e)
 	orig_eval(e)
 
-	if not MP.INTEGRATIONS.Preview then return end
-	FN.PRE.add_reset_event("after")
+    G.E_MANAGER:add_event(Event({
+        blocking = false,
+        func = function()
+            FN.PRE.stop_current_coroutine()
+            return true
+        end
+    }))
 end
 
 local orig_discard = G.FUNCS.discard_cards_from_highlighted
 function G.FUNCS.discard_cards_from_highlighted(e, is_hook_blind)
 	orig_discard(e, is_hook_blind)
 
-	if not MP.INTEGRATIONS.Preview then return end
-	if not is_hook_blind then FN.PRE.add_reset_event("immediate") end
+	if not is_hook_blind then FN.PRE.stop_current_coroutine() end
 end
 
 -- USER INTERFACE ADVICE:

--- a/compatibility/Preview/EngineSimulate.lua
+++ b/compatibility/Preview/EngineSimulate.lua
@@ -2,7 +2,7 @@
 
 if not FN.SIM.run then
 	function FN.SIM.run()
-		local null_ret = { score = { min = 0, exact = 0, max = 0 }, dollars = { min = 0, exact = 0, max = 0 } }
+		local null_ret = { score = { min = 0, exact = 0, max = 0 }, dollars = { min = 0, exact = 0, max = 0 }, empty = true }
 		if #G.hand.highlighted < 1 then return null_ret end
 
 		FN.SIM.init()

--- a/compatibility/Preview/InitPreview.lua
+++ b/compatibility/Preview/InitPreview.lua
@@ -23,12 +23,11 @@ FN.PRE = {
 
 
 function FN.PRE.start_new_coroutine()
-    local delay, calculate_cost = 0, 5
-	if MP.LOBBY.code and not MP.is_pvp_boss() then
-        delay = 1.5
-        if MP.is_layer_active("speedlatro_timer") then
-            delay = calculate_cost
-        end
+    local timer_delay, timer_cost = 0, 0
+    if MP.LOBBY and MP.LOBBY.code and not MP.is_pvp_boss() then
+        local ruleset = MP.Rulesets[MP.LOBBY.config.ruleset] or {}
+        timer_delay = MP.LOBBY.config.preview_calculate_delay or ruleset.preview_calculate_delay or 1.5
+        timer_cost  = MP.LOBBY.config.preview_calculate_cost or ruleset.preview_calculate_cost or 5
     end
 
     if not FN.PRE.calculate_request then
@@ -41,22 +40,18 @@ function FN.PRE.start_new_coroutine()
             FN.PRE.data = FN.PRE.simulate()
 
             -- Subtract cost from timer
-            if FN.PRE.data and not FN.PRE.data.empty and MP.LOBBY.code and not MP.is_pvp_boss() then
-                if MP.LOBBY.config.timer and (MP.GAME.timer or 0) > 10 then
-                    local decrement = (calculate_cost - delay)
-                    if decrement ~= 0 then                        
-                        MP.GAME.timer = MP.GAME.timer - decrement
-                        local timer_ui = G.HUD:get_UIE_by_ID("timer_UI_count")
-                        if timer_ui then
-                            timer_ui.config.object:juice_up()
-                        end
-                    end
-                end
+            -- Since it's event, we check everything all over again
+            if
+                FN.PRE.data and not FN.PRE.data.empty
+                and MP.LOBBY.code and not MP.is_pvp_boss()
+            then
+                -- Die due to timer consume all your time is lame, let's prevent this
+                MP.UI.consume_timer(timer_cost - timer_delay, nil, math.max(10, timer_cost))
             end
             return true
         end
         FN.PRE.calculate_request = Event({
-            trigger = "after", delay = delay, timer = "REAL",
+            trigger = "after", delay = timer_delay, timer = "REAL",
             blockable = false, blocking = false,
             func = func
         })

--- a/compatibility/Preview/InitPreview.lua
+++ b/compatibility/Preview/InitPreview.lua
@@ -24,7 +24,12 @@ FN.PRE = {
 
 function FN.PRE.start_new_coroutine()
     local delay, calculate_cost = 0, 5
-	if MP.LOBBY.code and not MP.is_pvp_boss() then delay = 1.5 end
+	if MP.LOBBY.code and not MP.is_pvp_boss() then
+        delay = 1.5
+        if MP.is_layer_active("speedlatro_timer") then
+            delay = calculate_cost
+        end
+    end
 
     if not FN.PRE.calculate_request then
         FN.PRE.lock_updates = true
@@ -38,10 +43,13 @@ function FN.PRE.start_new_coroutine()
             -- Subtract cost from timer
             if FN.PRE.data and not FN.PRE.data.empty and MP.LOBBY.code and not MP.is_pvp_boss() then
                 if MP.LOBBY.config.timer and (MP.GAME.timer or 0) > 10 then
-                    MP.GAME.timer = MP.GAME.timer - (calculate_cost - delay)
-                    local timer_ui = G.HUD:get_UIE_by_ID("timer_UI_count")
-                    if timer_ui then
-                        timer_ui.config.object:juice_up()
+                    local decrement = (calculate_cost - delay)
+                    if decrement ~= 0 then                        
+                        MP.GAME.timer = MP.GAME.timer - decrement
+                        local timer_ui = G.HUD:get_UIE_by_ID("timer_UI_count")
+                        if timer_ui then
+                            timer_ui.config.object:juice_up()
+                        end
                     end
                 end
             end

--- a/compatibility/Preview/InitPreview.lua
+++ b/compatibility/Preview/InitPreview.lua
@@ -6,6 +6,7 @@ FN.PRE = {
 	data = {
 		score = { min = 0, exact = 0, max = 0 },
 		dollars = { min = 0, exact = 0, max = 0 },
+        empty = true,
 	},
 	text = {
 		score = { l = "", r = "" },
@@ -17,26 +18,57 @@ FN.PRE = {
 	lock_updates = false,
 	on_startup = true,
 	five_second_coroutine = nil,
+    calculate_request = nil,
 }
 
--- this coroutine nonsense is pissing me off so i'm doing events instead
--- it's fine because a calc takes close to no computing time
--- function name is the same, can't be bothered
 
 function FN.PRE.start_new_coroutine()
-	FN.PRE.lock_updates = true
-	FN.PRE.show_preview = true
-	FN.PRE.add_update_event("immediate") -- Force UI refresh
-	local delay = 0
-	if MP.LOBBY.code and not MP.is_pvp_boss() then delay = 5 * G.SETTINGS.GAMESPEED end
-	local func = function()
-		FN.PRE.simulate()
-		FN.PRE.lock_updates = false
-		FN.PRE.show_preview = true
-		FN.PRE.add_update_event("immediate") -- Refresh UI again
-		return true
-	end
-	G.E_MANAGER:add_event(Event({ trigger = "after", blockable = false, blocking = false, delay = delay, func = func }))
+    local delay, calculate_cost = 0, 5
+	if MP.LOBBY.code and not MP.is_pvp_boss() then delay = 1.5 end
+
+    if not FN.PRE.calculate_request then
+        FN.PRE.lock_updates = true
+        FN.PRE.show_preview = true
+        local func = function()
+            FN.PRE.calculate_request = nil
+            FN.PRE.lock_updates = false
+            FN.PRE.show_preview = true
+            FN.PRE.data = FN.PRE.simulate()
+
+            -- Subtract cost from timer
+            if FN.PRE.data and not FN.PRE.data.empty and MP.LOBBY.code and not MP.is_pvp_boss() then
+                if MP.LOBBY.config.timer and (MP.GAME.timer or 0) > 10 then
+                    MP.GAME.timer = MP.GAME.timer - (calculate_cost - delay)
+                    local timer_ui = G.HUD:get_UIE_by_ID("timer_UI_count")
+                    if timer_ui then
+                        timer_ui.config.object:juice_up()
+                    end
+                end
+            end
+            return true
+        end
+        FN.PRE.calculate_request = Event({
+            trigger = "after", delay = delay, timer = "REAL",
+            blockable = false, blocking = false,
+            func = func
+        })
+        G.E_MANAGER:add_event(FN.PRE.calculate_request)
+    end
+end
+
+function FN.PRE.stop_current_coroutine(no_interrupt)
+    if not MP.INTEGRATIONS.Preview then return end
+    if no_interrupt and FN.PRE.lock_updates then return end
+    if FN.PRE.show_preview then
+        FN.PRE.show_preview = false
+        FN.PRE.data = FN.PRE.cleanup()
+    end
+    if FN.PRE.calculate_request then
+        FN.PRE.calculate_request.func = function() return true end
+        FN.PRE.calculate_request.complete = true
+        FN.PRE.calculate_request = nil
+        FN.PRE.lock_updates = false
+    end
 end
 
 --[[

--- a/core.lua
+++ b/core.lua
@@ -168,7 +168,6 @@ function MP.reset_lobby_config(persist_ruleset_and_gamemode)
 		starting_lives = 4,
 		pvp_start_round = 2,
 		timer_base_seconds = 240,
-		timer_increment_seconds = 60,
 		pvp_countdown_seconds = 3,
 		showdown_starting_antes = 3,
 		ruleset = persist_ruleset_and_gamemode and MP.LOBBY.config.ruleset or "ruleset_mp_blitz",

--- a/core.lua
+++ b/core.lua
@@ -229,6 +229,7 @@ function MP.reset_game_states()
 		highest_score = MP.INSANE_INT.empty(),
 		timer = MP.LOBBY.config.timer_base_seconds,
 		timer_started = false,
+        timer_consumed = false,
 		pvp_countdown = 0,
 		real_money = 0,
 		ce_cache = false,

--- a/core.lua
+++ b/core.lua
@@ -167,7 +167,7 @@ function MP.reset_lobby_config(persist_ruleset_and_gamemode)
 		the_order = true,
 		starting_lives = 4,
 		pvp_start_round = 2,
-		timer_base_seconds = 150,
+		timer_base_seconds = 240,
 		timer_increment_seconds = 60,
 		pvp_countdown_seconds = 3,
 		showdown_starting_antes = 3,

--- a/layers/speedlatro_timer.lua
+++ b/layers/speedlatro_timer.lua
@@ -1,7 +1,11 @@
 -- speedlatro specific timer
 -- i can't be bothered to do run_start hooks and risk that being janky so it'll be initialized in gupdate
 
-MP.Layer("speedlatro_timer", {})
+MP.Layer("speedlatro_timer", {
+    preview_calculate_delay = 5,
+    preview_calculate_cost  = 5,
+    timer_speedup_multiplier = 2,
+})
 
 local base_timer = 147
 
@@ -78,7 +82,9 @@ function Game:update(dt)
 
 				if (not MP.is_pvp_boss()) or MP.INSANE_INT.greater_than(MP.GAME.enemy.score, self_score) then
 					local mult = 1
-					if MP.GAME.nemesis_timer_started and not MP.is_pvp_boss() then mult = 2 end
+					if MP.GAME.nemesis_timer_started and not MP.is_pvp_boss() then
+                        mult = MP.LOBBY.config.timer_speedup_multiplier or MP.Rulesets[MP.LOBBY.config.ruleset].timer_speedup_multiplier or 2
+                    end
 					MP.speedlatro_timer.real = MP.speedlatro_timer.real - dt * mult
 				end
 			end

--- a/layers/speedlatro_timer.lua
+++ b/layers/speedlatro_timer.lua
@@ -22,6 +22,7 @@ function Game:update(dt)
 								{
 									n = G.UIT.O,
 									config = {
+                                        func = "mp_update_speedlatro_timer",
 										object = DynaText({
 											scale = 1.1,
 											string = { { ref_table = MP.speedlatro_timer, ref_value = "display" } },
@@ -77,7 +78,7 @@ function Game:update(dt)
 
 				if (not MP.is_pvp_boss()) or MP.INSANE_INT.greater_than(MP.GAME.enemy.score, self_score) then
 					local mult = 1
-					if MP.GAME.timer_started and not MP.is_pvp_boss() then mult = 2 end
+					if MP.GAME.nemesis_timer_started and not MP.is_pvp_boss() then mult = 2 end
 					MP.speedlatro_timer.real = MP.speedlatro_timer.real - dt * mult
 				end
 			end
@@ -154,4 +155,12 @@ function end_round()
 		end
 	end
 	return end_round_ref()
+end
+
+G.FUNCS.mp_update_speedlatro_timer = function(e)
+    if e.config.object then
+        e.config.object.colours[1] = (MP.GAME.nemesis_timer_started and not MP.is_pvp_boss() and MP.speedlatro_timer.real > 0)
+            and SMODS.Gradients["mp_speedlatro_timer_accelerated"]
+            or G.C.WHITE
+    end
 end

--- a/layers/standard.lua
+++ b/layers/standard.lua
@@ -1,6 +1,9 @@
 MP.Layer("standard", {
 	multiplayer_content = true,
 	standard = true,
+    preview_calculate_delay = 1.5,
+    preview_calculate_cost  = 5,
+    timer_speedup_multiplier = 2,
 	banned_silent = {
 		"j_hanging_chad",
 		"j_ticket",

--- a/lib/matchmaking.lua
+++ b/lib/matchmaking.lua
@@ -33,7 +33,18 @@ function MP:generate_hash()
 	local mod_string = table.concat(mod_data, ";")
 	MP.MOD_STRING = mod_string
 	MP.MOD_HASH = hash(mod_string) or "0000"
-	MP.ACTIONS.set_username(MP.LOBBY.username)
+    if MP.ACTIONS.set_username then
+        function MP.ACTIONS.set_username(username)
+            MP.LOBBY.username = username or "Guest"
+            if MP.LOBBY.connected then
+                Client.send({
+                    action = "username",
+                    username = MP.LOBBY.username .. "~" .. MP.LOBBY.blind_col,
+                    modHash = MP.MOD_STRING,
+                })
+            end
+        end
+    end
 end
 
 local hash_generated = false

--- a/lib/matchmaking.lua
+++ b/lib/matchmaking.lua
@@ -34,16 +34,7 @@ function MP:generate_hash()
 	MP.MOD_STRING = mod_string
 	MP.MOD_HASH = hash(mod_string) or "0000"
     if MP.ACTIONS.set_username then
-        function MP.ACTIONS.set_username(username)
-            MP.LOBBY.username = username or "Guest"
-            if MP.LOBBY.connected then
-                Client.send({
-                    action = "username",
-                    username = MP.LOBBY.username .. "~" .. MP.LOBBY.blind_col,
-                    modHash = MP.MOD_STRING,
-                })
-            end
-        end
+        MP.ACTIONS.set_username(MP.LOBBY.username)
     end
 end
 

--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -853,6 +853,9 @@ local function action_start_ante_timer(time, from_nemesis)
     if from_nemesis then
         MP.GAME.nemesis_timer_started = true
         SMODS.Gradients.mp_timer_accelerated.mp_gradient_delay = MP.GAME.timer % 1
+        if MP.speedlatro_timer then
+            SMODS.Gradients.mp_timer_accelerated.speedlatro_timer_accelerated = MP.speedlatro_timer.real % 1
+        end
     else
         MP.GAME.timer_started = true
     end

--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -432,7 +432,6 @@ local function action_lobby_options(options)
 			k == "starting_lives"
 			or k == "pvp_start_round"
 			or k == "timer_base_seconds"
-			or k == "timer_increment_seconds"
 			or k == "showdown_starting_antes"
 			or k == "pvp_countdown_seconds"
 			or k == "timer_forgiveness"

--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -255,8 +255,9 @@ end
 local function action_start_blind()
 	MP.GAME.ready_blind = false
 	MP.GAME.timer_started = false
-	MP.GAME.timer = MP.LOBBY.config.timer_base_seconds
+	MP.GAME.nemesis_timer_started = false
     MP.GAME.timer_consumed = false
+	MP.GAME.timer = MP.LOBBY.config.timer_base_seconds
 	MP.UI.start_pvp_countdown(begin_pvp_blind)
 end
 
@@ -349,6 +350,7 @@ local function action_end_pvp()
 	MP.GAME.timer = MP.LOBBY.config.timer_base_seconds
     MP.GAME.timer_consumed = false
 	MP.GAME.timer_started = false
+	MP.GAME.nemesis_timer_started = false
 	MP.GAME.ready_blind = false
 
 end
@@ -825,11 +827,7 @@ local function action_receive_nemesis_deck(deck_str)
 	G.FUNCS.load_nemesis_deck()
 end
 
-local function action_start_ante_timer(time)
-    if true then
-        print("Clicking on a timer do nothing for now")
-        return
-    end
+local function action_start_ante_timer(time, from_nemesis)
 	local option = SMODS.Mods["Multiplayer"].config.timersfx or 1
 	local timersfx = (option == 1) or (option == 2 and G.timer_ante ~= G.GAME.round_resets.ante)
 	G.timer_ante = G.GAME.round_resets.ante
@@ -850,20 +848,25 @@ local function action_start_ante_timer(time)
 			}))
 		end
 	end
-	if type(time) == "string" then time = tonumber(time) end
-	MP.GAME.timer = time
-	MP.GAME.timer_started = true
+	-- if type(time) == "string" then time = tonumber(time) end
+	-- MP.GAME.timer = time
+    if from_nemesis then
+        MP.GAME.nemesis_timer_started = true
+        SMODS.Gradients.mp_timer_accelerated.mp_gradient_delay = MP.GAME.timer % 1
+    else
+        MP.GAME.timer_started = true
+    end
 	-- if not MP.is_layer_active("speedlatro_timer") then G.E_MANAGER:add_event(MP.timer_event) end
 end
 
-local function action_pause_ante_timer(time)
-    if true then
-        print("Clicking on a timer do nothing for now")
-        return
+local function action_pause_ante_timer(time, from_nemesis)
+	-- if type(time) == "string" then time = tonumber(time) end
+	-- MP.GAME.timer = time
+    if from_nemesis then
+        MP.GAME.nemesis_timer_started = false
+    else
+        MP.GAME.timer_started = false
     end
-	if type(time) == "string" then time = tonumber(time) end
-	MP.GAME.timer = time
-	MP.GAME.timer_started = false
 end
 
 -- #region Client to Server
@@ -1127,9 +1130,6 @@ function MP.ACTIONS.request_nemesis_stats()
 end
 
 function MP.ACTIONS.start_ante_timer()
-    if true then
-        print("Clicking on a timer do nothing for now")
-    end
 	Client.send({
 		action = "startAnteTimer",
 		time = MP.GAME.timer,
@@ -1138,9 +1138,6 @@ function MP.ACTIONS.start_ante_timer()
 end
 
 function MP.ACTIONS.pause_ante_timer()
-    if true then
-        print("Clicking on a timer do nothing for now")
-    end
 	Client.send({
 		action = "pauseAnteTimer",
 		time = MP.GAME.timer,
@@ -1324,9 +1321,9 @@ function Game:update(dt)
 			elseif parsedAction.action == "nemesisEndGameStats" then
 				-- Handle receiving game stats (is only logged now, now shown in the ui)
 			elseif parsedAction.action == "startAnteTimer" then
-				action_start_ante_timer(parsedAction.time)
+				action_start_ante_timer(parsedAction.time, true)
 			elseif parsedAction.action == "pauseAnteTimer" then
-				action_pause_ante_timer(parsedAction.time)
+				action_pause_ante_timer(parsedAction.time, true)
 			elseif parsedAction.action == "jimboAppear" then
 				action_jimbo_appear(parsedAction.pos, parsedAction.text)
 			elseif parsedAction.action == "jimboTalk" then

--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -256,6 +256,7 @@ local function action_start_blind()
 	MP.GAME.ready_blind = false
 	MP.GAME.timer_started = false
 	MP.GAME.timer = MP.LOBBY.config.timer_base_seconds
+    MP.GAME.timer_consumed = false
 	MP.UI.start_pvp_countdown(begin_pvp_blind)
 end
 
@@ -346,6 +347,7 @@ end
 local function action_end_pvp()
 	MP.GAME.end_pvp = true
 	MP.GAME.timer = MP.LOBBY.config.timer_base_seconds
+    MP.GAME.timer_consumed = false
 	MP.GAME.timer_started = false
 	MP.GAME.ready_blind = false
 
@@ -824,6 +826,10 @@ local function action_receive_nemesis_deck(deck_str)
 end
 
 local function action_start_ante_timer(time)
+    if true then
+        print("Clicking on a timer do nothing for now")
+        return
+    end
 	local option = SMODS.Mods["Multiplayer"].config.timersfx or 1
 	local timersfx = (option == 1) or (option == 2 and G.timer_ante ~= G.GAME.round_resets.ante)
 	G.timer_ante = G.GAME.round_resets.ante
@@ -847,10 +853,14 @@ local function action_start_ante_timer(time)
 	if type(time) == "string" then time = tonumber(time) end
 	MP.GAME.timer = time
 	MP.GAME.timer_started = true
-	if not MP.is_layer_active("speedlatro_timer") then G.E_MANAGER:add_event(MP.timer_event) end
+	-- if not MP.is_layer_active("speedlatro_timer") then G.E_MANAGER:add_event(MP.timer_event) end
 end
 
 local function action_pause_ante_timer(time)
+    if true then
+        print("Clicking on a timer do nothing for now")
+        return
+    end
 	if type(time) == "string" then time = tonumber(time) end
 	MP.GAME.timer = time
 	MP.GAME.timer_started = false
@@ -1117,6 +1127,9 @@ function MP.ACTIONS.request_nemesis_stats()
 end
 
 function MP.ACTIONS.start_ante_timer()
+    if true then
+        print("Clicking on a timer do nothing for now")
+    end
 	Client.send({
 		action = "startAnteTimer",
 		time = MP.GAME.timer,
@@ -1125,6 +1138,9 @@ function MP.ACTIONS.start_ante_timer()
 end
 
 function MP.ACTIONS.pause_ante_timer()
+    if true then
+        print("Clicking on a timer do nothing for now")
+    end
 	Client.send({
 		action = "pauseAnteTimer",
 		time = MP.GAME.timer,

--- a/rulesets/majorleague.lua
+++ b/rulesets/majorleague.lua
@@ -19,7 +19,7 @@ MP.Ruleset({
 		return false
 	end,
 	force_lobby_options = function(self)
-		MP.LOBBY.config.timer_base_seconds = 180
+		MP.LOBBY.config.timer_base_seconds = 300
 		MP.LOBBY.config.timer_forgiveness = 1
 		MP.LOBBY.config.the_order = false
 		MP.LOBBY.config.preview_disabled = true

--- a/rulesets/minorleague.lua
+++ b/rulesets/minorleague.lua
@@ -16,7 +16,7 @@ MP.Ruleset({
 	forced_gamemode = "gamemode_mp_attrition",
 	forced_lobby_options = true,
 	force_lobby_options = function(self)
-		MP.LOBBY.config.timer_base_seconds = 210
+		MP.LOBBY.config.timer_base_seconds = 360
 		MP.LOBBY.config.timer_forgiveness = 1
 		MP.LOBBY.config.the_order = true
 		return true

--- a/ui/game/enemy_location.lua
+++ b/ui/game/enemy_location.lua
@@ -197,6 +197,7 @@ function MP.UI.enemy_location_definition()
 end
 
 function MP.UI.show_enemy_location()
+    if not G.HUD then return end
 	local row_dollars_chips = G.HUD:get_UIE_by_ID("row_dollars_chips")
 	if row_dollars_chips then
 		row_dollars_chips.children[1]:remove()
@@ -205,6 +206,7 @@ function MP.UI.show_enemy_location()
 	end
 end
 function MP.UI.hide_enemy_location()
+    if not G.HUD then return end
 	local row_dollars_chips = G.HUD:get_UIE_by_ID("row_dollars_chips")
 	if row_dollars_chips then
 		row_dollars_chips.children[1]:remove()
@@ -214,6 +216,7 @@ function MP.UI.hide_enemy_location()
 end
 
 function MP.UI.update_enemy_location_render()
+    if not G.HUD then return end
 	local renderer = G.HUD:get_UIE_by_ID("mp_enemy_location_render")
 	if renderer then
 		local blind_object_render = MP.UI.enemy_location_blind_render()

--- a/ui/game/functions.lua
+++ b/ui/game/functions.lua
@@ -329,7 +329,7 @@ function MP.UI.ease_lives(mod)
 			end
 
 			local lives_UI = G.hand_text_area.ante
-			if not lives_UI then return true end
+			if not lives_UI or not lives_UI.config.object then return true end
 
 			mod = mod or 0
 			local text = "+"

--- a/ui/game/functions.lua
+++ b/ui/game/functions.lua
@@ -72,7 +72,7 @@ local skip_blind_ref = G.FUNCS.skip_blind
 G.FUNCS.skip_blind = function(e)
 	skip_blind_ref(e)
 	if MP.LOBBY.code then
-		if not MP.GAME.timer_started then MP.GAME.timer = MP.GAME.timer + MP.LOBBY.config.timer_increment_seconds end
+		-- if not MP.GAME.timer_started then MP.GAME.timer = MP.GAME.timer + MP.LOBBY.config.timer_increment_seconds end
 		MP.ACTIONS.skip(G.GAME.skips)
 
 		--Update the furthest blind

--- a/ui/game/functions.lua
+++ b/ui/game/functions.lua
@@ -72,7 +72,6 @@ local skip_blind_ref = G.FUNCS.skip_blind
 G.FUNCS.skip_blind = function(e)
 	skip_blind_ref(e)
 	if MP.LOBBY.code then
-		-- if not MP.GAME.timer_started then MP.GAME.timer = MP.GAME.timer + MP.LOBBY.config.timer_increment_seconds end
 		MP.ACTIONS.skip(G.GAME.skips)
 
 		--Update the furthest blind

--- a/ui/game/timer.lua
+++ b/ui/game/timer.lua
@@ -192,6 +192,9 @@ end
 local gameUpdateRef = Game.update
 ---@diagnostic disable-next-line: duplicate-set-field
 function Game:update(dt)
+    local new_time = os.clock()
+    local timer_dt = new_time - (MP.TIMER_CLOCK or new_time)
+    MP.TIMER_CLOCK = new_time
     if MP.LOBBY.code and MP.LOBBY.config.timer and not MP.GAME.timer_consumed and MP.GAME.timer and MP.GAME.timer > 0 then
         -- Do not tick when no pvp or we're ready
         if not MP.GAME.ready_blind and not MP.is_pvp_boss() then
@@ -200,7 +203,7 @@ function Game:update(dt)
             -- Do tick when game is paused or any overlay menu opened
             if not (G.CONTROLLER.locked or (G.GAME.STOP_USE or 0) > 0) or (G.SETTINGS.paused or G.OVERLAY_MENU) then
                 local timer_mult = MP.GAME.nemesis_timer_started and 2 or 1
-                MP.GAME.timer = MP.GAME.timer - G.real_dt * timer_mult
+                MP.GAME.timer = MP.GAME.timer - timer_dt * timer_mult
                 if MP.GAME.timer <= 0 then
                     MP.GAME.timer = 0
                     MP.GAME.timer_consumed = true

--- a/ui/game/timer.lua
+++ b/ui/game/timer.lua
@@ -145,6 +145,22 @@ function MP.UI.start_pvp_countdown(callback)
 	}))
 end
 
+local gradient_with_offset_update = function(self, dt)
+    if #self.colours < 2 then return end
+    local timer = (G.TIMERS.REAL-(self.mp_gradient_delay or 0))%self.cycle
+    local start_index = math.ceil(timer*#self.colours/self.cycle)
+    local end_index = start_index == #self.colours and 1 or start_index+1
+    local start_colour, end_colour = self.colours[start_index], self.colours[end_index]
+    local partial_timer = (timer%(self.cycle/#self.colours))*#self.colours/self.cycle
+    for i = 1, 4 do
+        if self.interpolation == 'linear' then
+            self[i] = start_colour[i] + partial_timer*(end_colour[i]-start_colour[i])
+        elseif self.interpolation == 'trig' then
+            self[i] = start_colour[i] + 0.5*(1-math.cos(partial_timer*math.pi))*(end_colour[i]-start_colour[i])
+        end
+    end
+end
+
 SMODS.Gradient({
 	key = "timer_accelerated",
     cycle = 1,
@@ -155,21 +171,19 @@ SMODS.Gradient({
 		G.C.IMPORTANT,
 		G.C.IMPORTANT,
 	},
-    update = function(self, dt)
-        if #self.colours < 2 then return end
-        local timer = (G.TIMERS.REAL-(self.mp_gradient_delay or 0))%self.cycle
-        local start_index = math.ceil(timer*#self.colours/self.cycle)
-        local end_index = start_index == #self.colours and 1 or start_index+1
-        local start_colour, end_colour = self.colours[start_index], self.colours[end_index]
-        local partial_timer = (timer%(self.cycle/#self.colours))*#self.colours/self.cycle
-        for i = 1, 4 do
-            if self.interpolation == 'linear' then
-                self[i] = start_colour[i] + partial_timer*(end_colour[i]-start_colour[i])
-            elseif self.interpolation == 'trig' then
-                self[i] = start_colour[i] + 0.5*(1-math.cos(partial_timer*math.pi))*(end_colour[i]-start_colour[i])
-            end
-        end
-    end
+    update = gradient_with_offset_update
+})
+SMODS.Gradient({
+	key = "speedlatro_timer_accelerated",
+    cycle = 1,
+	colours = {
+        G.C.WHITE,
+		G.C.WHITE,
+		G.C.WHITE,
+		G.C.WHITE,
+		mix_colours(G.C.IMPORTANT, G.C.WHITE, 0.55),
+	},
+    update = gradient_with_offset_update
 })
 
 function G.FUNCS.set_timer_box(e)
@@ -192,10 +206,16 @@ end
 local gameUpdateRef = Game.update
 ---@diagnostic disable-next-line: duplicate-set-field
 function Game:update(dt)
+    -- os.clock() used specifically to prevent timer stalling when game window is grabbed
+    -- Secret tech, shhh
     local new_time = os.clock()
     local timer_dt = new_time - (MP.TIMER_CLOCK or new_time)
     MP.TIMER_CLOCK = new_time
-    if MP.LOBBY.code and MP.LOBBY.config.timer and not MP.GAME.timer_consumed and MP.GAME.timer and MP.GAME.timer > 0 then
+    if 
+        not MP.is_layer_active("speedlatro_timer") and MP.LOBBY.code
+        and MP.LOBBY.config.timer and not MP.GAME.timer_consumed
+        and MP.GAME.timer and MP.GAME.timer > 0
+    then
         -- Do not tick when no pvp or we're ready
         if not MP.GAME.ready_blind and not MP.is_pvp_boss() then
             -- Do tick when user can interact with a game

--- a/ui/game/timer.lua
+++ b/ui/game/timer.lua
@@ -52,8 +52,8 @@ function MP.UI.timer_hud()
 						minw = 1.2,
 						colour = G.C.DYN_UI.BOSS_DARK,
 						id = "row_round_text",
-						func = "set_timer_box",
-						button = "mp_timer_button",
+						-- func = "set_timer_box",
+						-- button = "mp_timer_button",
 					},
 					nodes = {
 						{
@@ -61,8 +61,17 @@ function MP.UI.timer_hud()
 							config = {
 								object = DynaText({
 									string = MP.is_layer_active("speedlatro_timer") and ">>"
-										or { { ref_table = MP.GAME, ref_value = "timer" } }, -- sorry
-									colours = { G.C.UI.TEXT_DARK },
+										or { { ref_table = setmetatable({}, {
+                                            __index = function()
+                                                if not MP.GAME.timer then return 0 end
+                                                -- All numbers bigger then 10 - display as integer
+                                                -- Also accounting for rounding to prevent 10.0 to be displayed
+                                                if MP.GAME.timer > 9.95 then return string.format("%d", MP.GAME.timer) end
+                                                -- Less than 10 - display decimap part
+                                                return string.format("%.1f", MP.GAME.timer)
+                                            end,
+                                        }), ref_value = "timer" } }, -- sorry
+									colours = { G.C.IMPORTANT },
 									shadow = true,
 									scale = 0.8,
 								}),
@@ -149,32 +158,34 @@ function G.FUNCS.set_timer_box(e)
 			return
 		end
 		e.config.colour = G.C.DYN_UI.BOSS_DARK
-		e.children[1].config.object.colours = { G.C.UI.TEXT_DARK }
+		e.children[1].config.object.colours = { G.C.IMPORTANT }
 	end
 end
 
-MP.timer_event = Event({
-	blockable = false,
-	blocking = false,
-	pause_force = true,
-	no_delete = true,
-	trigger = "after",
-	delay = 1,
-	timer = "UPTIME",
-	func = function()
-		if not MP.GAME.timer_started then return true end
-		MP.GAME.timer = MP.GAME.timer - 1
-		if MP.GAME.timer <= 0 then
-			MP.GAME.timer = 0
-			if not MP.GAME.ready_blind and not MP.is_pvp_boss() then
-				if MP.GAME.timers_forgiven < MP.LOBBY.config.timer_forgiveness then
-					MP.GAME.timers_forgiven = MP.GAME.timers_forgiven + 1
-					return true
-				end
-				MP.ACTIONS.fail_timer()
-			end
-			return true
-		end
-		MP.timer_event.start_timer = false
-	end,
-})
+local gameUpdateRef = Game.update
+---@diagnostic disable-next-line: duplicate-set-field
+function Game:update(dt)
+    if MP.LOBBY.code and MP.GAME and not MP.GAME.timer_consumed and MP.GAME.timer and MP.GAME.timer > 0 then
+        -- Do not tick when no pvp or we're ready
+        if not MP.GAME.ready_blind and not MP.is_pvp_boss() then
+            -- Do tick when user can interact with a game
+            -- OR
+            -- Do tick when game is paused or any overlay menu opened
+            if not (G.CONTROLLER.locked or (G.GAME.STOP_USE or 0) > 0) or (G.SETTINGS.paused or G.OVERLAY_MENU) then
+                MP.GAME.timer = MP.GAME.timer - G.real_dt
+                if MP.GAME.timer <= 0 then
+                    MP.GAME.timer = 0
+                    MP.GAME.timer_consumed = true
+                    if not MP.GAME.ready_blind and not MP.is_pvp_boss() then
+                        if MP.GAME.timers_forgiven < MP.LOBBY.config.timer_forgiveness then
+                            MP.GAME.timers_forgiven = MP.GAME.timers_forgiven + 1
+                        else
+                            MP.ACTIONS.fail_timer()
+                        end
+                    end
+                end
+            end
+        end
+    end
+	gameUpdateRef(self, dt)
+end

--- a/ui/game/timer.lua
+++ b/ui/game/timer.lua
@@ -235,7 +235,8 @@ function Game:update(dt)
     local menu_or_paused = G.SETTINGS.paused or G.OVERLAY_MENU
     if not (interactive or menu_or_paused) then return end
 
-    local mult = MP.GAME.nemesis_timer_started and 2 or 1
+    local mult_value = MP.LOBBY.config.timer_speedup_multiplier or MP.Rulesets[MP.LOBBY.config.ruleset].timer_speedup_multiplier or 2
+    local mult = MP.GAME.nemesis_timer_started and mult_value or 1
     MP.GAME.timer = math.max(0, MP.GAME.timer - timer_dt * mult)
 
     if MP.GAME.timer == 0 then
@@ -244,6 +245,23 @@ function Game:update(dt)
             MP.GAME.timers_forgiven = MP.GAME.timers_forgiven + 1
         else
             MP.ACTIONS.fail_timer()
+        end
+    end
+end
+
+function MP.UI.consume_timer(amount, silent, min_timer)
+    if
+        amount > 0
+        and MP.LOBBY.config.timer
+        and MP.GAME.timer
+        and MP.GAME.timer > (min_timer or 0)
+    then
+        MP.GAME.timer = math.max(0, MP.GAME.timer - amount)
+        if not silent then
+            local timer_ui = G.HUD:get_UIE_by_ID("timer_UI_count")
+            if timer_ui then
+                timer_ui.config.object:juice_up()
+            end
         end
     end
 end

--- a/ui/game/timer.lua
+++ b/ui/game/timer.lua
@@ -67,7 +67,7 @@ function MP.UI.timer_hud()
                                                 -- All numbers bigger then 10 - display as integer
                                                 -- Also accounting for rounding to prevent 10.0 to be displayed
                                                 if MP.GAME.timer > 9.95 then return string.format("%d", MP.GAME.timer) end
-                                                -- Less than 10 - display decimap part
+                                                -- Less than 10 - display decimal part
                                                 return string.format("%.1f", MP.GAME.timer)
                                             end,
                                         }), ref_value = "timer" } }, -- sorry
@@ -206,37 +206,44 @@ end
 local gameUpdateRef = Game.update
 ---@diagnostic disable-next-line: duplicate-set-field
 function Game:update(dt)
-    -- os.clock() used specifically to prevent timer stalling when game window is grabbed
-    -- Secret tech, shhh
-    local new_time = os.clock()
+    gameUpdateRef(self, dt)
+
+    -- If I let timer tick only when we're in MP context
+    -- then big jump of dt will happend between state changes.
+    -- So we need count time all the time. Sad!
+
+    -- Again, we cannot rely on any variant of dt since game does not
+    -- update at all while window is grabbed,
+    -- and when you release it dt does not reflect time wasted
+
+    -- This thing cost NOTHING im comparision to game drawing and UI updating
+    -- We can afford some inefficiencies.
+    local new_time = love.timer.getTime()
     local timer_dt = new_time - (MP.TIMER_CLOCK or new_time)
     MP.TIMER_CLOCK = new_time
-    if 
-        not MP.is_layer_active("speedlatro_timer") and MP.LOBBY.code
-        and MP.LOBBY.config.timer and not MP.GAME.timer_consumed
-        and MP.GAME.timer and MP.GAME.timer > 0
-    then
-        -- Do not tick when no pvp or we're ready
-        if not MP.GAME.ready_blind and not MP.is_pvp_boss() then
-            -- Do tick when user can interact with a game
-            -- OR
-            -- Do tick when game is paused or any overlay menu opened
-            if not (G.CONTROLLER.locked or (G.GAME.STOP_USE or 0) > 0) or (G.SETTINGS.paused or G.OVERLAY_MENU) then
-                local timer_mult = MP.GAME.nemesis_timer_started and 2 or 1
-                MP.GAME.timer = MP.GAME.timer - timer_dt * timer_mult
-                if MP.GAME.timer <= 0 then
-                    MP.GAME.timer = 0
-                    MP.GAME.timer_consumed = true
-                    if not MP.GAME.ready_blind and not MP.is_pvp_boss() then
-                        if MP.GAME.timers_forgiven < MP.LOBBY.config.timer_forgiveness then
-                            MP.GAME.timers_forgiven = MP.GAME.timers_forgiven + 1
-                        else
-                            MP.ACTIONS.fail_timer()
-                        end
-                    end
-                end
-            end
+
+    -- Bail fast: not an MP PvP-timer context
+    if not MP.LOBBY.code then return end
+    if not MP.LOBBY.config.timer then return end
+    if MP.GAME.timer_consumed then return end
+    if not MP.GAME.timer or MP.GAME.timer <= 0 then return end
+    if MP.is_layer_active("speedlatro_timer") then return end
+    if MP.GAME.ready_blind or MP.is_pvp_boss() then return end
+
+    -- Don't tick during animations, unless the user is paused or has a menu open
+    local interactive = not (G.CONTROLLER.locked or (G.GAME.STOP_USE or 0) > 0)
+    local menu_or_paused = G.SETTINGS.paused or G.OVERLAY_MENU
+    if not (interactive or menu_or_paused) then return end
+
+    local mult = MP.GAME.nemesis_timer_started and 2 or 1
+    MP.GAME.timer = math.max(0, MP.GAME.timer - timer_dt * mult)
+
+    if MP.GAME.timer == 0 then
+        MP.GAME.timer_consumed = true
+        if MP.GAME.timers_forgiven < MP.LOBBY.config.timer_forgiveness then
+            MP.GAME.timers_forgiven = MP.GAME.timers_forgiven + 1
+        else
+            MP.ACTIONS.fail_timer()
         end
     end
-	gameUpdateRef(self, dt)
 end

--- a/ui/game/timer.lua
+++ b/ui/game/timer.lua
@@ -52,8 +52,8 @@ function MP.UI.timer_hud()
 						minw = 1.2,
 						colour = G.C.DYN_UI.BOSS_DARK,
 						id = "row_round_text",
-						-- func = "set_timer_box",
-						-- button = "mp_timer_button",
+						func = "set_timer_box",
+						button = "mp_timer_button",
 					},
 					nodes = {
 						{
@@ -145,11 +145,38 @@ function MP.UI.start_pvp_countdown(callback)
 	}))
 end
 
+SMODS.Gradient({
+	key = "timer_accelerated",
+    cycle = 1,
+	colours = {
+		mix_colours(G.C.WHITE, G.C.IMPORTANT, 0.55),
+		G.C.IMPORTANT,
+		G.C.IMPORTANT,
+		G.C.IMPORTANT,
+		G.C.IMPORTANT,
+	},
+    update = function(self, dt)
+        if #self.colours < 2 then return end
+        local timer = (G.TIMERS.REAL-(self.mp_gradient_delay or 0))%self.cycle
+        local start_index = math.ceil(timer*#self.colours/self.cycle)
+        local end_index = start_index == #self.colours and 1 or start_index+1
+        local start_colour, end_colour = self.colours[start_index], self.colours[end_index]
+        local partial_timer = (timer%(self.cycle/#self.colours))*#self.colours/self.cycle
+        for i = 1, 4 do
+            if self.interpolation == 'linear' then
+                self[i] = start_colour[i] + partial_timer*(end_colour[i]-start_colour[i])
+            elseif self.interpolation == 'trig' then
+                self[i] = start_colour[i] + 0.5*(1-math.cos(partial_timer*math.pi))*(end_colour[i]-start_colour[i])
+            end
+        end
+    end
+})
+
 function G.FUNCS.set_timer_box(e)
 	if MP.LOBBY.config.timer then
-		if MP.GAME.timer_started then
+		if MP.GAME.timer_started or MP.GAME.nemesis_timer_started then
 			e.config.colour = G.C.DYN_UI.BOSS_DARK
-			e.children[1].config.object.colours = { G.C.IMPORTANT }
+			e.children[1].config.object.colours = { MP.GAME.timer > 0 and SMODS.Gradients["mp_timer_accelerated"] or G.C.IMPORTANT }
 			return
 		end
 		if not MP.GAME.timer_started and MP.GAME.ready_blind then
@@ -165,14 +192,15 @@ end
 local gameUpdateRef = Game.update
 ---@diagnostic disable-next-line: duplicate-set-field
 function Game:update(dt)
-    if MP.LOBBY.code and MP.GAME and not MP.GAME.timer_consumed and MP.GAME.timer and MP.GAME.timer > 0 then
+    if MP.LOBBY.code and MP.LOBBY.config.timer and not MP.GAME.timer_consumed and MP.GAME.timer and MP.GAME.timer > 0 then
         -- Do not tick when no pvp or we're ready
         if not MP.GAME.ready_blind and not MP.is_pvp_boss() then
             -- Do tick when user can interact with a game
             -- OR
             -- Do tick when game is paused or any overlay menu opened
             if not (G.CONTROLLER.locked or (G.GAME.STOP_USE or 0) > 0) or (G.SETTINGS.paused or G.OVERLAY_MENU) then
-                MP.GAME.timer = MP.GAME.timer - G.real_dt
+                local timer_mult = MP.GAME.nemesis_timer_started and 2 or 1
+                MP.GAME.timer = MP.GAME.timer - G.real_dt * timer_mult
                 if MP.GAME.timer <= 0 then
                     MP.GAME.timer = 0
                     MP.GAME.timer_consumed = true

--- a/ui/lobby/_lobby_options/modifiers_tab.lua
+++ b/ui/lobby/_lobby_options/modifiers_tab.lua
@@ -41,7 +41,7 @@ function MP.UI.create_gamemode_modifiers_tab()
 						"k_opts_pvp_timer",
 						0.85,
 						{ "90s", "120s", "150s", "180s", "210s", "240s", "270s", "300s", "330s", "360s" },
-						(MP.LOBBY.config.timer_base_seconds - 60) / 30,
+						MP.UTILS.get_array_index_by_value({ 90, 120, 150, 180, 210, 240, 270, 300, 330, 360 }, MP.LOBBY.config.timer_base_seconds) or 6, -- Default is 240
 						"change_timer_base_seconds"
 					),
 					create_lobby_option_cycle(

--- a/ui/lobby/_lobby_options/modifiers_tab.lua
+++ b/ui/lobby/_lobby_options/modifiers_tab.lua
@@ -9,11 +9,6 @@ G.FUNCS.change_timer_base_seconds = function(args)
 	send_lobby_options()
 end
 
-G.FUNCS.change_timer_increment_seconds = function(args)
-	MP.LOBBY.config.timer_increment_seconds = tonumber(args.to_val:sub(1, -2))
-	send_lobby_options()
-end
-
 G.FUNCS.change_showdown_starting_antes = function(args)
 	MP.LOBBY.config.showdown_starting_antes = args.to_val
 	send_lobby_options()
@@ -49,17 +44,6 @@ function MP.UI.create_gamemode_modifiers_tab()
 						(MP.LOBBY.config.timer_base_seconds - 60) / 30,
 						"change_timer_base_seconds"
 					),
-					-- create_lobby_option_cycle(
-					-- 	"pvp_timer_increment_seconds_option",
-					-- 	"k_opts_pvp_timer_increment",
-					-- 	0.85,
-					-- 	{ "0s", "30s", "60s", "90s", "120s", "150s", "180s" },
-					-- 	MP.UTILS.get_array_index_by_value(
-					-- 		{ 0, 30, 60, 90, 120, 150, 180 },
-					-- 		MP.LOBBY.config.timer_increment_seconds
-					-- 	),
-					-- 	"change_timer_increment_seconds"
-					-- ),
 					create_lobby_option_cycle(
 						"pvp_round_start_option",
 						"k_opts_pvp_start_round",

--- a/ui/lobby/_lobby_options/modifiers_tab.lua
+++ b/ui/lobby/_lobby_options/modifiers_tab.lua
@@ -45,21 +45,21 @@ function MP.UI.create_gamemode_modifiers_tab()
 						"pvp_timer_seconds_option",
 						"k_opts_pvp_timer",
 						0.85,
-						{ "30s", "60s", "90s", "120s", "150s", "180s", "210s", "240s" },
-						MP.LOBBY.config.timer_base_seconds / 30,
+						{ "90s", "120s", "150s", "180s", "210s", "240s", "270s", "300s", "330s", "360s" },
+						(MP.LOBBY.config.timer_base_seconds - 60) / 30,
 						"change_timer_base_seconds"
 					),
-					create_lobby_option_cycle(
-						"pvp_timer_increment_seconds_option",
-						"k_opts_pvp_timer_increment",
-						0.85,
-						{ "0s", "30s", "60s", "90s", "120s", "150s", "180s" },
-						MP.UTILS.get_array_index_by_value(
-							{ 0, 30, 60, 90, 120, 150, 180 },
-							MP.LOBBY.config.timer_increment_seconds
-						),
-						"change_timer_increment_seconds"
-					),
+					-- create_lobby_option_cycle(
+					-- 	"pvp_timer_increment_seconds_option",
+					-- 	"k_opts_pvp_timer_increment",
+					-- 	0.85,
+					-- 	{ "0s", "30s", "60s", "90s", "120s", "150s", "180s" },
+					-- 	MP.UTILS.get_array_index_by_value(
+					-- 		{ 0, 30, 60, 90, 120, 150, 180 },
+					-- 		MP.LOBBY.config.timer_increment_seconds
+					-- 	),
+					-- 	"change_timer_increment_seconds"
+					-- ),
 					create_lobby_option_cycle(
 						"pvp_round_start_option",
 						"k_opts_pvp_start_round",


### PR DESCRIPTION
This PR implements completely new timer.

- Base timer value adjusted from 150 seconds to 240 seconds (300 seconds Major League Balatro, 360 seconds Minor League)
- Timer starts ticking from the start of a game
- Timer reset every ante except first one
- Timer DOES NOT tick when user cannot interact with a game, such as waiting for animation (examples: using planet, playing hand, drawing cards)
- Timer DOES tick when any menu is opened or game is paused (examples: Run Info, Deck, Escape menu) to prevent stalling
- Skipping does not give any additional time
- "Timering" opponent increases timer speed by 2x, which is also visually represented by pulsing colour
  - Same pulsing also added for Speedlatro timer

Some changes applied for Fantom's Preview:
- Artificial delay of calculating score decreased from 5s -> 1.5s
- When score calculated, 3.5 seconds is deducted from timer
  - As a result, cost of calculate stays 5 seconds
- Prevented simulating score outside of "Calculate" button press (optimization measure)
  - Simulation was happening on every card selecting, deselection, discarding, usage, etc.
  
## Things to do:
- Playtest new timer in matches, adjust base timer value, "timering" multiplier