### PR TITLE
Fix TAB shortcut menu blocking debug overlay during runs

### DIFF
--- a/ui/shortcuts_menu.lua
+++ b/ui/shortcuts_menu.lua
@@ -259,11 +259,9 @@ function Controller:key_press_update(key, dt)
 		end
 	end
 
-	if key == "tab" then
-		if not G.OVERLAY_MENU then
-			MP.SHORTCUTS.show()
-			return
-		end
+	if key == "tab" and not G.OVERLAY_MENU then
+		MP.SHORTCUTS.show()
+		if MP.SHORTCUTS.visible then return end
 	end
 	key_press_update_ref(self, key, dt)
 end


### PR DESCRIPTION
## Summary
- TAB was always swallowed by the shortcuts menu, even when the menu had nothing to show (e.g. during a run), which blocked the debug overlay.
- Now only intercept TAB when the menu actually becomes visible; otherwise fall through to the original key handler.

## Test plan
- [ ] Start a run and press TAB — debug overlay should open as normal.
- [ ] From a menu where the shortcuts menu has entries, hold TAB — shortcuts menu still appears.