### PR TITLE
Layer scalar resolution: last wins instead of first

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -116,7 +116,7 @@ Solo endurance — 1 life, no PvP blinds at all (all vanilla). Bans adversarial 
 
 `MP.resolve_layers(init)` runs **before** SMODS construction (because SMODS validates `required_params` in `__call`, not `inject()`). Left-to-right:
 - **Array fields** (`banned_*`, `reworked_*`): concatenated (union of all layers + ruleset additions)
-- **Scalar fields**: first layer wins; ruleset-level always overrides
+- **Scalar fields**: last layer wins; ruleset-level always overrides
 - Missing `banned_*`/`reworked_*` arrays default to `{}`
 
 ### Runtime query: `MP.is_layer_active(name)`

--- a/layers/_layers.lua
+++ b/layers/_layers.lua
@@ -21,32 +21,38 @@ MP._LAYER_ARRAY_FIELDS = {
 	"reworked_blinds",
 }
 
--- Resolve layers on the init table before SMODS construction validates required_params
+-- Resolve layers on the init table before SMODS construction validates required_params.
+-- Scalars: last layer wins, but the ruleset's own value always beats any layer.
+-- Arrays: concatenated across all layers + ruleset.
 function MP.resolve_layers(init)
 	if not init.layers then return init end
+	local ruleset_owned = {}
+	for k in pairs(init) do
+		ruleset_owned[k] = true
+	end
 	for _, layer_name in ipairs(init.layers) do
 		local layer = MP.Layers[layer_name]
 		if not layer then error("Unknown layer: " .. tostring(layer_name)) end
 		for k, v in pairs(layer) do
-			if init[k] == nil then
-				if type(v) == "table" then
+			if type(v) == "table" then
+				if init[k] == nil then
 					local copy = {}
 					for i, item in ipairs(v) do
 						copy[i] = item
 					end
 					init[k] = copy
-				else
-					init[k] = v
+				elseif type(init[k]) == "table" then
+					local merged = {}
+					for _, item in ipairs(v) do
+						merged[#merged + 1] = item
+					end
+					for _, item in ipairs(init[k]) do
+						merged[#merged + 1] = item
+					end
+					init[k] = merged
 				end
-			elseif type(v) == "table" and type(init[k]) == "table" then
-				local merged = {}
-				for _, item in ipairs(v) do
-					merged[#merged + 1] = item
-				end
-				for _, item in ipairs(init[k]) do
-					merged[#merged + 1] = item
-				end
-				init[k] = merged
+			elseif not ruleset_owned[k] then
+				init[k] = v
 			end
 		end
 	end


### PR DESCRIPTION
## Summary
- `MP.resolve_layers` now resolves scalar layer fields with last-layer-wins instead of first-layer-wins. Ruleset-level scalars still override all layers; array fields still concat.
- Aligns scalar precedence with `MP.LoadReworks`, which already resolves vanilla → layers in order → self.
- Updates `agents.md` to match.

## Why
First-wins meant a later, more-specific layer in a ruleset's `layers = {...}` list couldn't refine a base layer's scalar — the inverse of how the rework system works. No current ruleset has a colliding scalar across its layers (verified by inspecting every layer file), so behavior is unchanged today; this is a semantic fix to make future composition predictable.

## Test plan
- [x] Local harness exercising `resolve_layers` directly (`.context/verify_layer_resolution.lua`, gitignored): 14/14 checks pass — covers last-wins on scalars, ruleset > layers precedence, array concat, function-typed scalars, default empty arrays, and `_layer_order` preservation.
- [x] Smoke test in-game: load each ruleset (Blitz, Traditional, SmallWorld, Speedlatro, Chaos, Sandbox, Legacy Ranked, Vanilla, Badlatro, MajorLeague, MinorLeague, Ranked) and confirm bans/reworks/forced options behave as before.