### PR TITLE
Update lobby info UI; Add skips display

### DIFF
--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -1136,6 +1136,7 @@ return {
 			k_wait_enemy = "Waiting for enemy to finish...",
 			k_wait_enemy_reach_this_blind = "Waiting for enemy to reach this blind...",
 			k_lives = "Lives",
+            k_skips = "Skips",
 			k_lost_life = "Lost a life",
 			k_total_lives_lost = " Total Lives Lost",
 			k_comeback_money_sandbox = " Comeback Money ($3 × ante cleared)",

--- a/ui/game/functions.lua
+++ b/ui/game/functions.lua
@@ -331,7 +331,7 @@ function MP.UI.ease_lives(mod, instant)
 			end
 
 			local lives_UI = G.hand_text_area.ante
-			if not lives_UI then return true end
+			if not lives_UI or not lives_UI.config.object then return true end
 
 			mod = mod or 0
 			local text = "+"

--- a/ui/game/lobby_info.lua
+++ b/ui/game/lobby_info.lua
@@ -246,13 +246,14 @@ function MP.UI.create_UIBox_player_row(type)
 							{
 								n = G.UIT.T,
 								config = {
-									text = tostring(skips) .. " " .. localize("b_skip"),
+									text = tostring(skips) .. " " .. localize("k_skips"),
 									scale = 0.4,
 									colour = G.C.UI.TEXT_LIGHT,
 								},
 							},
 						},
 					},
+                    -- Let's keep it for future, just in case
 					-- {
 					-- 	n = G.UIT.C,
 					-- 	config = { align = "cr", padding = 0.01, r = 0.1, colour = G.C.CHIPS, minw = 1.1 },

--- a/ui/game/lobby_info.lua
+++ b/ui/game/lobby_info.lua
@@ -156,15 +156,17 @@ function MP.UI.create_UIBox_player_row(type)
 	local player_name = type == "host" and MP.LOBBY.host.username or MP.LOBBY.guest.username
 	local lives = MP.GAME.enemy.lives
 	local highest_score = MP.GAME.enemy.highest_score
+	local skips = MP.GAME.enemy.skips or 0
 	if (type == "host" and MP.LOBBY.is_host) or (type == "guest" and not MP.LOBBY.is_host) then
 		lives = MP.GAME.lives
 		highest_score = MP.GAME.highest_score
+		skips = G.GAME.skips or 0
 	end
 	return {
 		n = G.UIT.R,
 		config = {
 			align = "cm",
-			padding = 0.05,
+			padding = 0.1,
 			r = 0.1,
 			colour = darken(G.C.JOKER_GREY, 0.1),
 			emboss = 0.05,
@@ -178,18 +180,18 @@ function MP.UI.create_UIBox_player_row(type)
 		nodes = {
 			{
 				n = G.UIT.C,
-				config = { align = "cl", padding = 0, minw = 5 },
+				config = { align = "cm", padding = 0.05, r = 0.1, colour = G.C.BLACK },
 				nodes = {
 					{
 						n = G.UIT.C,
 						config = {
 							align = "cm",
-							padding = 0.02,
+							padding = 0.025,
 							r = 0.1,
-							colour = G.C.RED,
+							colour = G.C.MULT,
 							minw = 2,
-							outline = 0.8,
-							outline_colour = G.C.RED,
+							outline = 0.5,
+							outline_colour = G.C.MULT,
 						},
 						nodes = {
 							{
@@ -202,6 +204,12 @@ function MP.UI.create_UIBox_player_row(type)
 							},
 						},
 					},
+				},
+			},
+			{
+				n = G.UIT.C,
+				config = { align = "cl", padding = 0, minw = 4 },
+				nodes = {
 					{
 						n = G.UIT.C,
 						config = { align = "cm", minw = 4.5, maxw = 4.5 },
@@ -209,7 +217,7 @@ function MP.UI.create_UIBox_player_row(type)
 							{
 								n = G.UIT.T,
 								config = {
-									text = " " .. player_name,
+									text = "" .. player_name,
 									scale = 0.45,
 									colour = G.C.UI.TEXT_LIGHT,
 									shadow = true,
@@ -225,39 +233,61 @@ function MP.UI.create_UIBox_player_row(type)
 				nodes = {
 					{
 						n = G.UIT.C,
-						config = { align = "cr", padding = 0.01, r = 0.1, colour = G.C.CHIPS, minw = 1.1 },
-						nodes = {
-							{
-								n = G.UIT.T,
-								config = {
-									text = "???", -- Will be hands in the future
-									scale = 0.45,
-									colour = G.C.UI.TEXT_LIGHT,
-								},
-							},
-							{ n = G.UIT.B, config = { w = 0.08, h = 0.01 } },
+						config = {
+							align = "cm",
+							padding = 0.025,
+							r = 0.1,
+							colour = G.C.PURPLE,
+							minw = 1.75,
+							outline = 0.5,
+							outline_colour = G.C.PURPLE,
 						},
-					},
-					{
-						n = G.UIT.C,
-						config = { align = "cl", padding = 0.01, r = 0.1, colour = G.C.MULT, minw = 1.1 },
 						nodes = {
-							{ n = G.UIT.B, config = { w = 0.08, h = 0.01 } },
 							{
 								n = G.UIT.T,
 								config = {
-									text = "???", -- Will be discards in the future
-									scale = 0.45,
+									text = tostring(skips) .. " " .. localize("b_skip"),
+									scale = 0.4,
 									colour = G.C.UI.TEXT_LIGHT,
 								},
 							},
 						},
 					},
+					-- {
+					-- 	n = G.UIT.C,
+					-- 	config = { align = "cr", padding = 0.01, r = 0.1, colour = G.C.CHIPS, minw = 1.1 },
+					-- 	nodes = {
+					-- 		{
+					-- 			n = G.UIT.T,
+					-- 			config = {
+					-- 				text = "???", -- Will be hands in the future
+					-- 				scale = 0.45,
+					-- 				colour = G.C.UI.TEXT_LIGHT,
+					-- 			},
+					-- 		},
+					-- 		{ n = G.UIT.B, config = { w = 0.08, h = 0.01 } },
+					-- 	},
+					-- },
+					-- {
+					-- 	n = G.UIT.C,
+					-- 	config = { align = "cl", padding = 0.01, r = 0.1, colour = G.C.MULT, minw = 1.1 },
+					-- 	nodes = {
+					-- 		{ n = G.UIT.B, config = { w = 0.08, h = 0.01 } },
+					-- 		{
+					-- 			n = G.UIT.T,
+					-- 			config = {
+					-- 				text = "???", -- Will be discards in the future
+					-- 				scale = 0.45,
+					-- 				colour = G.C.UI.TEXT_LIGHT,
+					-- 			},
+					-- 		},
+					-- 	},
+					-- },
 				},
 			},
 			{
 				n = G.UIT.C,
-				config = { align = "cm", padding = 0.05, colour = G.C.L_BLACK, r = 0.1, minw = 1.5 },
+				config = { align = "cm", padding = 0.05, colour = G.C.L_BLACK, r = 0.1, minw = 3, maxw = 3 },
 				nodes = {
 					{
 						n = G.UIT.T,


### PR DESCRIPTION
Lobby info got small cosmetic and functional changes:
- Always "???" red/blue fields was commented, maybe we'll find use for them layer
- Added display for amount of skips opponent did (purple colour). Makes checking Skip-Off in collection redundant.
  - *on a screenshot it says "0 Skip", in PR it's localized as "0 Skips"*
- Field for player's score is bigger and have max width limit to prevent UI drifting on big score numbers
- Small visual adjustments

<img width="1846" height="1057" alt="Balatro_YkrKqpbPy8" src="https://github.com/user-attachments/assets/3ac47d8f-a8c8-4667-89b6-3f56db7ac4a5" />

