### PR TITLE
Ranked 0.4.0: standard layer reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@
 #### Economy & Enhancements
 
 - **Gold Card** (Enhancement) — Payout increased from $3 to $4.
-- **Gold Seal** — Payout increased from $3 to $4.
 
 #### Balanced Sticker
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 #### Economy & Enhancements
 
 - **Gold Card** (Enhancement) — Payout increased from $3 to $4.
+- **Comeback Gold** — Now awarded on any life loss again, not just PvP boss losses. Payout amounts ($4, or $2 on higher stakes) are unchanged.
 
 ### Quality of Life
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,12 @@
 
 - **Gold Card** (Enhancement) — Payout increased from $3 to $4.
 
-#### Balanced Sticker
+### Quality of Life
 
-The Balanced sticker now shows a tooltip explaining what was changed.
+- **Balanced Sticker** — Now shows a tooltip explaining what was changed on the card it's attached to.
+- **Hotkeys — Menu Shortcuts** — Hold Tab in the menu to see context-sensitive shortcuts. Main menu: **C** creates a lobby, **V** joins from clipboard. In a lobby: **C** copies the code, **L** leaves, **D** picks deck. Disconnected: **R** reconnects.
+- **Timer and score preview rework** - TODO
+- **Match Replays (Practice Mode)** — Practice against a ghost opponent replayed from a past match. Drop a Lovely log (`.log`) or exported `.json` into the `replays/` folder and it shows up in the replay picker. Accessed via Practice → Ruleset → Replay Picker. Flip perspective to play as either side.
 
 ### Legacy Ranked
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+## Ranked Update 0.4.0
+
+### Standard Ranked
+
+#### Jokers
+
+- **To Do List** — Reworked. Now pays $5 (up from $4). Target poker hand is chosen from all hands, not just discovered ones.
+- **Golden Ticket** — Reverted payout nerf, now earns $4 (up from $3)
+- **Baron** and **Mime** — Swapped rarities. Baron is now Uncommon ($5), Mime is now Rare ($8).
+- **Speedrun** — Out of rotation.
+- **Ouija** and **Ectoplasm** — Now cost $4 (bug fix).
+
+#### Consumables
+
+- **Justice** — Back in rotation.
+
+#### Economy & Enhancements
+
+- **Gold Card** (Enhancement) — Payout increased from $3 to $4.
+- **Gold Seal** — Payout increased from $3 to $4.
+
+#### Balanced Sticker
+
+The Balanced sticker now shows a tooltip explaining what was changed.
+
+### Legacy Ranked
+
+#### Jokers
+
+- **Hanging Chad** — Reworked. Retriggers first 2 cards instead of first card twice.
+
+## Ranked Update 0.3.0
+
+### Jokers
+
+- **Seltzer** — Lasts 8 hands instead of 10.
+- **Turtle Bean** — Grants +4 hand size instead of +5.
+- **Golden Ticket** — Earns $3 instead of $4. No longer requires Gold cards in deck. Now Uncommon rarity.
+- **Speedrun** — Can now activate for both players if the second player joins within 30 seconds.
+
+### Consumables
+
+- **Ouija** — Destroys 3 cards instead of converting all cards to a single suit and reducing hand size.
+- **Judgment** — Now draws from its own queue (vanilla behavior) on Orange Stake and above. Still uses the shop queue on lower stakes.

--- a/core.lua
+++ b/core.lua
@@ -300,6 +300,7 @@ end
 
 MP.load_mp_dir("objects/editions")
 MP.load_mp_dir("objects/enhancements")
+MP.load_mp_dir("objects/seals")
 MP.load_mp_dir("objects/stickers")
 MP.load_mp_dir("objects/blinds")
 MP.load_mp_dir("objects/decks")

--- a/layers/classic.lua
+++ b/layers/classic.lua
@@ -1,5 +1,11 @@
 MP.Layer("classic", {
 	multiplayer_content = false,
+	banned_silent = {
+		"j_hanging_chad",
+	},
+	reworked_jokers = {
+		"j_mp_hanging_chad",
+	},
 	reworked_enhancements = {
 		"m_mp_display_glass",
 	},

--- a/layers/standard.lua
+++ b/layers/standard.lua
@@ -12,13 +12,15 @@ MP.Layer("standard", {
 		"j_baron",
 		"j_mime",
 	},
+	banned_jokers = {
+		"j_mp_speedrun",
+	},
 	banned_consumables = {},
 	reworked_jokers = {
 		"j_mp_hanging_chad",
 		"j_mp_ticket",
 		"j_mp_seltzer",
 		"j_mp_turtle_bean",
-		-- NEW
 		"j_mp_baron",
 		"j_mp_mime",
 		"j_mp_todo_list",

--- a/layers/standard_old.lua
+++ b/layers/standard_old.lua
@@ -1,4 +1,4 @@
-MP.Layer("standard", {
+MP.Layer("standard_old", {
 	multiplayer_content = true,
 	standard = true,
 	banned_silent = {
@@ -8,26 +8,20 @@ MP.Layer("standard", {
 		"j_turtle_bean",
 		"j_bloodstone",
 		"c_ouija",
-		"j_todo_list",
-		"j_baron",
-		"j_mime",
 	},
-	banned_consumables = {},
+	banned_consumables = {
+		"c_justice",
+	},
 	reworked_jokers = {
 		"j_mp_hanging_chad",
 		"j_mp_ticket",
 		"j_mp_seltzer",
 		"j_mp_turtle_bean",
-		-- NEW
-		"j_mp_baron",
-		"j_mp_mime",
-		"j_mp_todo_list",
 	},
 	reworked_consumables = {
 		"c_mp_ouija_standard",
 	},
 	reworked_enhancements = {
 		"m_mp_display_glass",
-		"m_mp_display_gold",
 	},
 })

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -101,6 +101,29 @@ return {
 					"earn {C:money}$#1#{} when scored",
 				},
 			},
+			j_mp_baron = {
+				name = "Baron",
+				text = {
+					"Each {C:attention}King{} held in hand",
+					"gives {X:mult,C:white} X#1# {} Mult",
+				},
+			},
+			j_mp_mime = {
+				name = "Mime",
+				text = {
+					"Retrigger all card",
+					"{C:attention}held in hand{} abilities",
+				},
+			},
+			j_mp_todo_list = {
+				name = "To Do List",
+				text = {
+					"Earn {C:money}$#1#{} if {C:attention}poker hand",
+					"played is a {C:attention}#2#{},",
+					"poker hand changes",
+					"at end of round",
+				},
+			},
 			j_broken = {
 				name = "BROKEN",
 				text = {
@@ -785,6 +808,14 @@ return {
 					"destroy card",
 				},
 			},
+			m_mp_display_gold = {
+				name = "Gold Card",
+				text = {
+					"{C:money}$#1#{} if this card is",
+					"{C:attention}held in hand{}",
+					"at end of round",
+				},
+			},
 		},
 		Back = {
 			b_mp_cocktail = {
@@ -861,6 +892,82 @@ return {
 				text = {
 					"Made with friends from",
 					"Balatro University!",
+				},
+			},
+			mp_sticker_balanced = {
+				name = "Balanced",
+				text = {
+					"This card has been rebalanced",
+				},
+			},
+			mp_sticker_balanced_j_mp_hanging_chad = {
+				name = "Balanced",
+				text = {
+					"Retriggers first {C:attention}2{} cards",
+					"instead of first card twice",
+				},
+			},
+			mp_sticker_balanced_j_mp_ticket = {
+				name = "Balanced",
+				text = {
+					"Now {C:green}Uncommon{}",
+					"No {C:attention}Gold{} card requirement",
+				},
+			},
+			mp_sticker_balanced_j_mp_seltzer = {
+				name = "Balanced",
+				text = {
+					"Lasts {C:attention}8{} hands",
+					"instead of {C:attention}10{}",
+				},
+			},
+			mp_sticker_balanced_j_mp_turtle_bean = {
+				name = "Balanced",
+				text = {
+					"{C:attention}+4{} hand size",
+					"instead of {C:attention}+5{}",
+				},
+			},
+			mp_sticker_balanced_j_mp_baron = {
+				name = "Balanced",
+				text = {
+					"Now {C:green}Uncommon{} ({C:money}$5{})",
+					"instead of {C:red}Rare{} ({C:money}$8{})",
+				},
+			},
+			mp_sticker_balanced_j_mp_mime = {
+				name = "Balanced",
+				text = {
+					"Now {C:red}Rare{} ({C:money}$8{})",
+					"instead of {C:green}Uncommon{} ({C:money}$5{})",
+				},
+			},
+			mp_sticker_balanced_j_mp_todo_list = {
+				name = "Balanced",
+				text = {
+					"Earns {C:money}$5{} instead of {C:money}$4{}",
+					"Picks from {C:attention}all{} poker hands,",
+					"not just discovered ones",
+				},
+			},
+			mp_sticker_balanced_c_mp_ouija_standard = {
+				name = "Balanced",
+				text = {
+					"Destroys {C:attention}3{} cards instead of",
+					"converting all cards and losing",
+					"{C:attention}-1{} hand size",
+				},
+			},
+			mp_sticker_balanced_m_gold = {
+				name = "Balanced",
+				text = {
+					"Earns {C:money}$4{} instead of {C:money}$3{}",
+				},
+			},
+			mp_sticker_balanced_m_mp_display_gold = {
+				name = "Balanced",
+				text = {
+					"Earns {C:money}$4{} instead of {C:money}$3{}",
 				},
 			},
 			current_nemesis = {

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -1152,6 +1152,7 @@ return {
 	misc = {
 		labels = {
 			mp_phantom = "Phantom",
+			mp_sticker_balanced = "Balanced",
 			mp_sticker_extra_credit = "Extra Credit",
 			mp_sticker_persistent = "Persistent",
 			mp_sticker_unreliable = "Unreliable",

--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -360,10 +360,8 @@ end
 local function action_player_info(lives)
 	if MP.GAME.lives ~= lives then
 		if MP.GAME.lives ~= 0 and MP.LOBBY.config.gold_on_life_loss then
-			if MP.is_pvp_boss() or MP.is_major_league_ruleset() then
-				MP.GAME.comeback_bonus_given = false
-				MP.GAME.comeback_bonus = MP.GAME.comeback_bonus + 1
-			end
+			MP.GAME.comeback_bonus_given = false
+			MP.GAME.comeback_bonus = MP.GAME.comeback_bonus + 1
 		end
 		MP.UI.ease_lives(lives - MP.GAME.lives, true)
 		if MP.LOBBY.config.no_gold_on_round_loss and (G.GAME.blind and G.GAME.blind.dollars) then

--- a/objects/consumables/ouija.lua
+++ b/objects/consumables/ouija.lua
@@ -9,6 +9,7 @@ SMODS.Consumable({
 	key = "ouija_standard",
 	set = "Spectral",
 	atlas = "ouija_2",
+	cost = 4,
 	pos = { x = 0, y = 0 },
 	unlocked = true,
 	discovered = true,

--- a/objects/consumables/sandbox/ectoplasm.lua
+++ b/objects/consumables/sandbox/ectoplasm.lua
@@ -1,6 +1,7 @@
 SMODS.Consumable({
 	key = "ectoplasm_sandbox",
 	set = "Spectral",
+	cost = 4,
 	pos = { x = 8, y = 4 },
 	config = { mp_sticker_balanced = true },
 	loc_vars = function(self, info_queue, card)

--- a/objects/enhancements/mp_gold.lua
+++ b/objects/enhancements/mp_gold.lua
@@ -1,0 +1,18 @@
+MP.ReworkCenter("m_gold", {
+	layers = "standard",
+	config = { h_dollars = 4, mp_balanced = true },
+})
+
+-- Display-only gold for ruleset descriptions
+SMODS.Enhancement({
+	key = "display_gold",
+	config = { h_dollars = 4, mp_balanced = true },
+	pos = { x = 6, y = 0 },
+	no_collection = true,
+	loc_vars = function(self, info_queue, card)
+		return { vars = { card.ability.h_dollars } }
+	end,
+	in_pool = function(self, args)
+		return false
+	end,
+})

--- a/objects/jokers/standard/baron.lua
+++ b/objects/jokers/standard/baron.lua
@@ -1,0 +1,31 @@
+SMODS.Joker({
+	key = "baron",
+	no_collection = true,
+	unlocked = true,
+	discovered = true,
+	blueprint_compat = true,
+	rarity = 2,
+	cost = 5,
+	pos = { x = 6, y = 12 },
+	config = { extra = { xmult = 1.5 }, mp_balanced = true },
+	loc_vars = function(self, info_queue, card)
+		return { vars = { card.ability.extra.xmult } }
+	end,
+	calculate = function(self, card, context)
+		if context.individual and context.cardarea == G.hand and not context.end_of_round and context.other_card:get_id() == 13 then
+			if context.other_card.debuff then
+				return {
+					message = localize("k_debuffed"),
+					colour = G.C.RED,
+				}
+			else
+				return {
+					x_mult = card.ability.extra.xmult,
+				}
+			end
+		end
+	end,
+	mp_include = function(self)
+		return MP.is_layer_active("standard") and MP.LOBBY.code
+	end,
+})

--- a/objects/jokers/standard/hanging_chad.lua
+++ b/objects/jokers/standard/hanging_chad.lua
@@ -34,6 +34,6 @@ SMODS.Joker({
 		end
 	end,
 	mp_include = function(self)
-		return (MP.is_layer_active("standard") or MP.is_layer_active("sandbox")) and MP.LOBBY.code
+		return (MP.is_layer_active("standard") or MP.is_layer_active("sandbox") or MP.is_layer_active("classic")) and MP.LOBBY.code
 	end,
 })

--- a/objects/jokers/standard/mime.lua
+++ b/objects/jokers/standard/mime.lua
@@ -1,0 +1,21 @@
+SMODS.Joker({
+	key = "mime",
+	no_collection = true,
+	unlocked = true,
+	discovered = true,
+	blueprint_compat = true,
+	rarity = 3,
+	cost = 8,
+	pos = { x = 4, y = 1 },
+	config = { extra = { repetitions = 1 }, mp_balanced = true },
+	calculate = function(self, card, context)
+		if context.repetition and context.cardarea == G.hand and (next(context.card_effects[1]) or #context.card_effects > 1) then
+			return {
+				repetitions = card.ability.extra.repetitions,
+			}
+		end
+	end,
+	mp_include = function(self)
+		return MP.is_layer_active("standard") and MP.LOBBY.code
+	end,
+})

--- a/objects/jokers/standard/ticket.lua
+++ b/objects/jokers/standard/ticket.lua
@@ -7,7 +7,7 @@ SMODS.Joker({
 	rarity = 2,
 	cost = 6,
 	pos = { x = 5, y = 3 },
-	config = { extra = { dollars = 3 }, mp_balanced = true },
+	config = { extra = { dollars = 4 }, mp_balanced = true },
 	loc_vars = function(self, info_queue, card)
 		info_queue[#info_queue + 1] = G.P_CENTERS.m_gold
 		return { vars = { card.ability.extra.dollars } }

--- a/objects/jokers/standard/todo_list.lua
+++ b/objects/jokers/standard/todo_list.lua
@@ -1,0 +1,50 @@
+SMODS.Joker({
+	key = "todo_list",
+	no_collection = true,
+	unlocked = true,
+	discovered = true,
+	blueprint_compat = true,
+	rarity = 1,
+	cost = 4,
+	pos = { x = 4, y = 11 },
+	config = { extra = { dollars = 5, poker_hand = "High Card" }, mp_balanced = true },
+	loc_vars = function(self, info_queue, card)
+		return { vars = { card.ability.extra.dollars, localize(card.ability.extra.poker_hand, "poker_hands") } }
+	end,
+	calculate = function(self, card, context)
+		if context.before and context.scoring_name == card.ability.extra.poker_hand then
+			G.GAME.dollar_buffer = (G.GAME.dollar_buffer or 0) + card.ability.extra.dollars
+			return {
+				dollars = card.ability.extra.dollars,
+				func = function()
+					G.E_MANAGER:add_event(Event({
+						func = function()
+							G.GAME.dollar_buffer = 0
+							return true
+						end,
+					}))
+				end,
+			}
+		end
+		if context.end_of_round and context.game_over == false and context.main_eval and not context.blueprint then
+			local _poker_hands = {}
+			for handname, _ in pairs(G.GAME.hands) do
+				if handname ~= card.ability.extra.poker_hand then _poker_hands[#_poker_hands + 1] = handname end
+			end
+			card.ability.extra.poker_hand = pseudorandom_element(_poker_hands, "todo_list")
+			return {
+				message = localize("k_reset"),
+			}
+		end
+	end,
+	set_ability = function(self, card, initial, delay_sprites)
+		local _poker_hands = {}
+		for handname, _ in pairs(G.GAME.hands) do
+			if handname ~= card.ability.extra.poker_hand then _poker_hands[#_poker_hands + 1] = handname end
+		end
+		card.ability.extra.poker_hand = pseudorandom_element(_poker_hands, "todo_list")
+	end,
+	mp_include = function(self)
+		return MP.is_layer_active("standard") and MP.LOBBY.code
+	end,
+})

--- a/objects/seals/mp_gold_seal.lua
+++ b/objects/seals/mp_gold_seal.lua
@@ -1,0 +1,8 @@
+MP.ReworkCenter("Gold", {
+	center_table = "P_SEALS",
+	layers = "standard",
+	config = { extra = { p_dollars = 4 } },
+	get_p_dollars = function(self, card)
+		return card.ability.seal.extra.p_dollars
+	end,
+})

--- a/objects/seals/mp_gold_seal.lua
+++ b/objects/seals/mp_gold_seal.lua
@@ -1,8 +1,9 @@
-MP.ReworkCenter("Gold", {
-	center_table = "P_SEALS",
-	layers = "standard",
-	config = { extra = { p_dollars = 4 } },
-	get_p_dollars = function(self, card)
-		return card.ability.seal.extra.p_dollars
-	end,
-})
+-- Gold Seal $3 -> $4 rework commented out for 0.4.0; revisit later.
+-- MP.ReworkCenter("Gold", {
+-- 	center_table = "P_SEALS",
+-- 	layers = "standard",
+-- 	config = { extra = { p_dollars = 4 } },
+-- 	get_p_dollars = function(self, card)
+-- 		return card.ability.seal.extra.p_dollars
+-- 	end,
+-- })

--- a/objects/stickers/balanced.lua
+++ b/objects/stickers/balanced.lua
@@ -11,5 +11,12 @@ SMODS.Sticker({
 	badge_colour = G.C.MULTIPLAYER,
 	default_compat = false,
 	needs_enable_flag = true,
-	hide_badge = true,
+	hide_badge = false,
+	loc_vars = function(self, info_queue, card)
+		local key = "mp_sticker_balanced_" .. card.config.center_key
+		if G.localization.descriptions.Other[key] then
+			return { key = key }
+		end
+		return {}
+	end,
 })


### PR DESCRIPTION
Ranked 0.4.0 ships a standard layer that has been touched by human hands.

- **To Do List** rebuilt from the studs. Pays $5, picks targets from every poker hand instead of just discovered ones.
- **Baron** and **Mime** trade rarities.
- **Golden Ticket** un-nerfed ($4 again).
- **Speedrun** out of rotation. **Justice** back in.
- **Gold Card** enhancement: $3 → $4.
- **Ouija** and **Ectoplasm** now correctly cost $4.
- **Balanced sticker** finally explains itself.
- **Comeback money** is now awarded on any life loss again. Payout amounts ($4, or $2 on higher stakes) are unchanged.

Legacy ranked: **Hanging Chad** retriggers the first 2 cards instead of the first card twice.

Old standard preserved as `standard_old.lua`.

## TODO

- [x] Sticker localization currently displays "error" — needs fixing before merge.

## Test plan

- [ ] Boot a ranked lobby, eyeball each touched joker
- [ ] Confirm Balanced sticker tooltip renders on a stuck card
- [ ] Skim the localization diff for typos