### PR TITLE
Game over screen

### DIFF
--- a/ui/game/game_end.lua
+++ b/ui/game/game_end.lua
@@ -1,3 +1,46 @@
+function MP.UI.create_UIBox_round_scores_row_nemesis()
+    local label = localize({ type = "name_text", set = "Blind", key = "bl_mp_nemesis" })
+    local score_tab = {}
+    local label_w, score_w, h = 2.9, 1, 0.5
+
+    local blind_name_string
+    if MP.GHOST.is_active() then
+        blind_name_string = MP.GHOST.get_blind_name_ui() or "ERROR"
+    else
+        blind_name_string = (MP.LOBBY.is_host and MP.LOBBY.guest or MP.LOBBY.host or {})["username"] or "ERROR"
+    end
+
+    local nemesis_blind_col = MP.UTILS.get_nemesis_key()
+    local blind_choice = {}
+    blind_choice.animation = AnimatedSprite(0,0, 0.5, 0.5, G.ANIMATION_ATLAS["mp_player_blind_col"], G.P_BLINDS[nemesis_blind_col].pos)
+    blind_choice.animation:define_draw_steps({
+        {shader = 'dissolve', shadow_height = 0.05},
+        {shader = 'dissolve'}
+    })
+
+    score_tab = {
+        {n=G.UIT.C, config={align = "cm", minh = 0.7, padding = 0.1}, nodes={
+            {n=G.UIT.O, config={object = DynaText({string = blind_name_string, colours = {G.C.WHITE}, shadow = true, bump = true,maxw = 2.9, scale = 0.45})}}
+        }},
+        {n=G.UIT.C, config={align = "cm"}, nodes={
+            {n=G.UIT.O, config={object = blind_choice.animation}}
+        }},
+    }
+
+    local label_scale = 0.5
+
+    return {n=G.UIT.R, config={align = "cm", padding = 0.05, r = 0.1, colour = darken(G.C.JOKER_GREY, 0.1), emboss = 0.05, id = "mp_score_nemesis"}, nodes={
+        {n=G.UIT.R, config={align = "cm", padding = 0.02, minw = label_w, maxw = label_w}, nodes={
+            {n=G.UIT.T, config={text = label, scale = label_scale, colour = G.C.UI.TEXT_LIGHT, shadow = true}},
+        }},
+        {n=G.UIT.R, config={align = "cr"}, nodes={
+            {n=G.UIT.C, config={align = "cm", minh = h, r = 0.1, minw = label_w + 0.9, colour = G.C.BLACK, emboss = 0.05}, nodes={
+                {n=G.UIT.C, config={align = "cm", padding = 0.05, r = 0.1, minw = score_w}, nodes=score_tab},
+            }}
+        }},
+    }}
+end
+
 function MP.UI.create_UIBox_mp_game_end(has_won)
 	MP.end_game_jokers = CardArea(
 		0,
@@ -185,13 +228,49 @@ function MP.UI.create_UIBox_mp_game_end(has_won)
 								nodes = {
 									{
 										n = G.UIT.C,
-										config = { align = "cm", padding = 0.08 },
+										config = { padding = 0.08 },
 										nodes = {
 											create_UIBox_round_scores_row("hand"),
 											create_UIBox_round_scores_row("poker_hand"),
+                                            {
+                                                n = G.UIT.R,
+                                                config = {},
+                                                nodes = {
+                                                    {
+                                                        n = G.UIT.C,
+                                                        nodes = {
+                                                            create_UIBox_round_scores_row('cards_purchased', G.C.MONEY),
+                                                            {
+                                                                n = G.UIT.R,
+                                                                config = { minh = 0.08 },
+                                                            },
+                                                            create_UIBox_round_scores_row('times_rerolled', G.C.GREEN),
+                                                        }
+                                                    },
+                                                    {
+                                                        n = G.UIT.C,
+                                                        config = {minw = 0.08}
+                                                    },
+                                                    {
+                                                        n = G.UIT.C,
+                                                        nodes = {
+                                                            create_UIBox_round_scores_row('furthest_ante', G.C.FILTER),
+                                                            {
+                                                                n = G.UIT.R,
+                                                                config = { minh = 0.08 },
+                                                            },
+                                                            create_UIBox_round_scores_row('furthest_round', G.C.FILTER),
+                                                        }
+                                                    },
+                                                }
+                                            },
+                                            {
+                                                n = G.UIT.R,
+                                                config = { minh = 0.01 },
+                                            },
 											{
 												n = G.UIT.R,
-												config = { align = "cm", padding = 0.08, minw = 2 },
+												config = { align = "cm", minw = 2 },
 												nodes = {
 													{
 														n = G.UIT.T,
@@ -206,7 +285,7 @@ function MP.UI.create_UIBox_mp_game_end(has_won)
 											},
 											{
 												n = G.UIT.R,
-												config = { align = "cm", padding = 0.08, minw = 2 },
+												config = { align = "cm", minw = 2 },
 												nodes = {
 													{
 														n = G.UIT.T,
@@ -221,12 +300,12 @@ function MP.UI.create_UIBox_mp_game_end(has_won)
 											},
 											{
 												n = G.UIT.R,
-												config = { align = "cm", padding = 0.08, minw = 2 },
+												config = { align = "cm", minw = 2 },
 												nodes = {
 													{
 														n = G.UIT.T,
 														config = {
-															text = localize("ml_mp_kofi_message")[3],
+															text = localize("ml_mp_kofi_message")[3] .. " " .. localize("ml_mp_kofi_message")[4],
 															scale = 0.35,
 															colour = G.C.UI.TEXT_LIGHT,
 															col = true,
@@ -234,21 +313,12 @@ function MP.UI.create_UIBox_mp_game_end(has_won)
 													},
 												},
 											},
-											{
-												n = G.UIT.R,
-												config = { align = "cm", padding = 0.08, minw = 2 },
-												nodes = {
-													{
-														n = G.UIT.T,
-														config = {
-															text = localize("ml_mp_kofi_message")[4],
-															scale = 0.35,
-															colour = G.C.UI.TEXT_LIGHT,
-															col = true,
-														},
-													},
-												},
-											},
+                                            {
+                                                n = G.UIT.R,
+                                                config = {
+                                                    minh = 0.08
+                                                }
+                                            },
 											{
 												n = G.UIT.R,
 												config = {
@@ -302,8 +372,7 @@ function MP.UI.create_UIBox_mp_game_end(has_won)
 										n = G.UIT.C,
 										config = { align = "tr", padding = 0.08 },
 										nodes = {
-											create_UIBox_round_scores_row("furthest_ante", G.C.FILTER),
-											create_UIBox_round_scores_row("furthest_round", G.C.FILTER),
+											MP.UI.create_UIBox_round_scores_row_nemesis(),
 											create_UIBox_round_scores_row("seed", G.C.WHITE),
 											UIBox_button({
 												id = "copy_seed_button",
@@ -311,29 +380,29 @@ function MP.UI.create_UIBox_mp_game_end(has_won)
 												label = { localize("b_copy") },
 												colour = G.C.BLUE,
 												scale = 0.3,
-												minw = 2.3,
+												minw = 2.5, maxw = 2.5,
 												minh = 0.4,
 											}),
 											{
 												n = G.UIT.R,
-												config = { align = "cm", minh = 0.4, minw = 0.1 },
+												config = { align = "cm", minh = 0.45, minw = 0.1 },
 												nodes = {},
 											},
 											UIBox_button({
 												id = "from_game_won",
 												button = "mp_return_to_lobby",
 												label = { localize("b_return_lobby") },
-												minw = 2.5,
-												maxw = 2.5,
-												minh = 1,
+												minw = 4,
+												maxw = 4,
+												minh = 0.8,
 												focus_args = { nav = "wide", snap_to = true },
 											}),
 											UIBox_button({
 												button = "lobby_leave",
 												label = { localize("b_leave_lobby") },
-												minw = 2.5,
-												maxw = 2.5,
-												minh = 1,
+												minw = 4,
+												maxw = 4,
+												minh = 0.8,
 												focus_args = { nav = "wide" },
 											}),
 										},

--- a/ui/game/round.lua
+++ b/ui/game/round.lua
@@ -32,7 +32,10 @@ end
 
 local ease_round_ref = ease_round
 function ease_round(mod)
-	if MP.is_mp_or_ghost() and not MP.LOBBY.config.disable_live_and_timer_hud and MP.LOBBY.config.timer then return end
+	if MP.is_mp_or_ghost() and not MP.LOBBY.config.disable_live_and_timer_hud and MP.LOBBY.config.timer then
+        G.GAME.round = G.GAME.round + mod
+        return
+    end
 	ease_round_ref(mod)
 end
 


### PR DESCRIPTION
I made new win/lose screen because it was bad.
- Added displays for amount of rerolls and cards purchased
- Round display now work properly (by fixing blatant ease_round override)
- Added unique display of current nemesis's name and blind chip
- Visual corrections

<img width="1536" height="864" alt="Balatro_n6DwOIlusr" src="https://github.com/user-attachments/assets/fdbaa523-8670-4a8b-a579-0ab765ff845a" />
<img width="1536" height="864" alt="Balatro_c4K1SEW0Io" src="https://github.com/user-attachments/assets/a24d6bbc-4ce1-4304-be91-8835af36dff6" />
