### PR TITLE
comeback money given on deaths to PvE blinds

### DIFF
--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -360,10 +360,8 @@ end
 local function action_player_info(lives)
 	if MP.GAME.lives ~= lives then
 		if MP.GAME.lives ~= 0 and MP.LOBBY.config.gold_on_life_loss then
-			if MP.is_pvp_boss() or MP.is_major_league_ruleset() then
-				MP.GAME.comeback_bonus_given = false
-				MP.GAME.comeback_bonus = MP.GAME.comeback_bonus + 1
-			end
+			MP.GAME.comeback_bonus_given = false
+			MP.GAME.comeback_bonus = MP.GAME.comeback_bonus + 1
 		end
 		MP.UI.ease_lives(lives - MP.GAME.lives, true)
 		if MP.LOBBY.config.no_gold_on_round_loss and (G.GAME.blind and G.GAME.blind.dollars) then


### PR DESCRIPTION
simple commit, but gameplay tweak.

bacon reasoned that deaths to blinds in higher-level play are often results of random variance rather than falling behind on blind scaling. such deaths are incredibly punishing already (-1 life) and the more important changes to comeback money have been the flattening and halving on higher stakes, preserving the dynamic of weak, tough seeds.

comeback money isn't strong enough to the point where this would be "rewarding bad play" anymore. nobody will reconsider dropping a life. just let the unlucky players have the $2