### PR TITLE
Various fixes

### DIFF
--- a/compatibility/Preview/InitPreview.lua
+++ b/compatibility/Preview/InitPreview.lua
@@ -25,8 +25,11 @@ FN.PRE = {
 function FN.PRE.start_new_coroutine()
     -- Defaults are vanilla: free preview, slow (5s) delay.
     -- Layers like pressure_timer set both via ruleset scalars.
-    local timer_delay, timer_cost = 5, 0
+    local timer_delay, timer_cost = 0, 0
     if MP.LOBBY and MP.LOBBY.code and not MP.is_pvp_boss() then
+        timer_delay = 5
+        timer_cost = 0
+
         local ruleset = MP.Rulesets[MP.LOBBY.config.ruleset] or {}
         timer_delay = MP.LOBBY.config.preview_calculate_delay or ruleset.preview_calculate_delay or timer_delay
         timer_cost  = MP.LOBBY.config.preview_calculate_cost or ruleset.preview_calculate_cost or timer_cost

--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -330,6 +330,10 @@ local function action_enemy_info(score_str, hands_left_str, skips_str, lives_str
 		play_sound("holo1", 0.865, 0.9)
 		play_sound("gong", 0.765, 0.4)
 	end
+    if MP.GAME.enemy.skips < skips then
+        play_sound('negative', 0.865, 0.4)
+        play_sound("gong", 0.765, 0.4)
+    end
 
 	MP.GAME.enemy.hands = hands_left
 	MP.GAME.enemy.skips = skips

--- a/objects/blinds/nemesis.lua
+++ b/objects/blinds/nemesis.lua
@@ -30,6 +30,6 @@ SMODS.Blind({
 })
 
 function MP.is_pvp_boss()
-	if not G.GAME or not G.GAME.blind then return false end
+	if not G.GAME or not G.GAME.blind or not G.GAME.blind.config.blind then return false end
 	return G.GAME.blind.config.blind.key == "bl_mp_nemesis" or G.GAME.blind.pvp
 end

--- a/ui/game/timer.lua
+++ b/ui/game/timer.lua
@@ -252,6 +252,7 @@ function Game:update(dt)
     MP.TIMER_CLOCK = new_time
 
     -- Bail fast: not an MP PvP-timer context
+    if G.STATE == G.STATES.GAME_OVER then return end
     if not MP.LOBBY.code then return end
     if not MP.LOBBY.config.timer then return end
     if MP.GAME.timer_consumed then return end

--- a/ui/game/timer.lua
+++ b/ui/game/timer.lua
@@ -164,7 +164,10 @@ SMODS.Gradient({
         local ruleset = MP.Rulesets[MP.LOBBY.config.ruleset]
         local speedup = (ruleset and ruleset.timer_speedup_multiplier) or 1
 
-        local timer = (-(MP.GAME.timer or 0) / speedup)%self.cycle
+        -- When you "timering" opponent, timer stops and you cannot see is button pressed
+        -- So we need switch to real timer to make it flush
+        local time_value = MP.GAME.timer_started and G.TIMERS.REAL or -(MP.GAME.timer or 0)
+        local timer = (time_value / speedup)%self.cycle
         local start_index = math.ceil(timer*#self.colours/self.cycle)
         if start_index == 0 then start_index = 1 end
         local end_index = start_index == #self.colours and 1 or start_index+1

--- a/ui/game/timer.lua
+++ b/ui/game/timer.lua
@@ -228,7 +228,7 @@ function G.FUNCS.set_timer_box(e)
 		end
 		e.config.colour = G.C.DYN_UI.BOSS_DARK
         -- Attention text if pressure timer
-		e.children[1].config.object.colours = { MP.is_layer_active("pressure_timer") and G.C.IMPORTANT or G.C.UI.TEXT_DARK }
+		e.children[1].config.object.colours = { MP.is_layer_active("pressure_timer") and not MP.is_pvp_boss() and G.C.IMPORTANT or G.C.UI.TEXT_DARK }
 	end
 end
 


### PR DESCRIPTION
- Fixed calculate button be 5 seconds in singleplayer and in pvp blind
- Make gradient continue cycling when you "timering" opponent
- Added sound when opponent skips (distinct from dying sound)
- Prevent timer tick on game over screen, just in case