### PR TITLE
Fix CONTRIBUTING.md branch sync instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ git commit -m "your changes"
 
 ```bash
 # Sync and create branch
-git checkout main && git pull upstream main && git push origin main
+git checkout dev && git pull upstream dev && git push origin dev
 git checkout -b feature/your-feature
 
 # Develop → Format → Commit → Push → PR


### PR DESCRIPTION
The "Quick Start" snippet syncs from `main`, but the project's
default branch is `dev` and `main` is no longer kept current.
Following the previous instructions left new forks branched off
stale code: `origin/main` only has 2 commits not on `origin/dev`
(#387, #389) while `origin/dev` has many commits not on `main`.

This switches the three sync commands to use `dev` so feature
branches start at the actual tip.