### PR TITLE
Add Experimental ruleset

### DIFF
--- a/layers/_layers.lua
+++ b/layers/_layers.lua
@@ -1,9 +1,10 @@
 MP.Layers = {}
 
--- Reverse index: joker full key -> array of layer names that list it.
--- Used to auto-attach `mp_include` on jokers whose only gating is layer membership,
--- so the joker file doesn't have to repeat what the layer already declared.
+-- Reverse indices: full key -> array of layer names that list it.
+-- Used to auto-attach `mp_include` on cards whose only gating is layer membership,
+-- so the object file doesn't have to repeat what the layer already declared.
 MP._JOKER_LAYERS = {}
+MP._CONSUMABLE_LAYERS = {}
 
 function MP.Layer(name, definition)
 	MP.Layers[name] = definition
@@ -13,6 +14,22 @@ function MP.Layer(name, definition)
 			table.insert(MP._JOKER_LAYERS[joker_key], name)
 		end
 	end
+	if definition.reworked_consumables then
+		for _, consumable_key in ipairs(definition.reworked_consumables) do
+			MP._CONSUMABLE_LAYERS[consumable_key] = MP._CONSUMABLE_LAYERS[consumable_key] or {}
+			table.insert(MP._CONSUMABLE_LAYERS[consumable_key], name)
+		end
+	end
+end
+
+-- Build an mp_include closure that returns true iff any of the named layers is active.
+local function layer_membership_include(owning_layers)
+	return function(_)
+		for _, layer_name in ipairs(owning_layers) do
+			if MP.is_layer_active(layer_name) then return true end
+		end
+		return false
+	end
 end
 
 -- A small graft on SMODS.Joker:register. Any joker whose full key appears in some
@@ -20,7 +37,7 @@ end
 -- provided. By the time register runs the key is already prefixed, so we can look
 -- it up directly. is_layer_active fails closed outside a live ruleset context, and
 -- bespoke mp_include slips past untouched.
-local _original_register = SMODS.Joker.register
+local _original_joker_register = SMODS.Joker.register
 function SMODS.Joker:register()
 	if not self.mp_include and MP._JOKER_LAYERS[self.key] then
 		local owning_layers = MP._JOKER_LAYERS[self.key]
@@ -28,14 +45,25 @@ function SMODS.Joker:register()
 			"Auto-gating " .. self.key .. " on layers: " .. table.concat(owning_layers, ", "),
 			"MULTIPLAYER"
 		)
-		self.mp_include = function(_)
-			for _, layer_name in ipairs(owning_layers) do
-				if MP.is_layer_active(layer_name) then return true end
-			end
-			return false
-		end
+		self.mp_include = layer_membership_include(owning_layers)
 	end
-	return _original_register(self)
+	return _original_joker_register(self)
+end
+
+-- Same graft for consumables. The lovely patch in lovely/misc.toml that filters
+-- _pool entries by mp_include works on any center, so consumables behave the
+-- same way as jokers once mp_include is set.
+local _original_consumable_register = SMODS.Consumable.register
+function SMODS.Consumable:register()
+	if not self.mp_include and MP._CONSUMABLE_LAYERS[self.key] then
+		local owning_layers = MP._CONSUMABLE_LAYERS[self.key]
+		sendDebugMessage(
+			"Auto-gating " .. self.key .. " on layers: " .. table.concat(owning_layers, ", "),
+			"MULTIPLAYER"
+		)
+		self.mp_include = layer_membership_include(owning_layers)
+	end
+	return _original_consumable_register(self)
 end
 
 -- Array-valued fields that get merged (layer base + ruleset additions)
@@ -115,9 +143,7 @@ function MP.RunLayerHooks(hook_name)
 	if not ruleset or not ruleset._layer_order then return end
 	for _, layer_name in ipairs(ruleset._layer_order) do
 		local layer = MP.Layers[layer_name]
-		if layer and layer[hook_name] then
-			layer[hook_name]()
-		end
+		if layer and layer[hook_name] then layer[hook_name]() end
 	end
 end
 

--- a/layers/experimental.lua
+++ b/layers/experimental.lua
@@ -1,4 +1,4 @@
-MP.Layer("standard_old", {
+MP.Layer("experimental", {
 	multiplayer_content = true,
 	standard = true,
 	banned_silent = {
@@ -8,20 +8,29 @@ MP.Layer("standard_old", {
 		"j_turtle_bean",
 		"j_bloodstone",
 		"c_ouija",
+		"j_todo_list",
+		"j_baron",
+		"j_mime",
 	},
-	banned_consumables = {
-		"c_justice",
+	banned_jokers = {
+		"j_mp_speedrun",
 	},
+	banned_consumables = {},
 	reworked_jokers = {
 		"j_mp_hanging_chad",
 		"j_mp_ticket",
 		"j_mp_seltzer",
 		"j_mp_turtle_bean",
+		"j_mp_baron",
+		"j_mp_mime",
+		"j_mp_todo_list",
+		"j_mp_bloodstone",
 	},
 	reworked_consumables = {
 		"c_mp_ouija_standard",
 	},
 	reworked_enhancements = {
 		"m_mp_display_glass",
+		"m_mp_display_gold",
 	},
 })

--- a/layers/standard.lua
+++ b/layers/standard.lua
@@ -17,6 +17,7 @@ MP.Layer("standard", {
 		"j_mp_ticket",
 		"j_mp_seltzer",
 		"j_mp_turtle_bean",
+        "j_mp_bloodstone",
 	},
 	reworked_consumables = {
 		"c_mp_ouija_standard",

--- a/layers/standard.lua
+++ b/layers/standard.lua
@@ -8,29 +8,20 @@ MP.Layer("standard", {
 		"j_turtle_bean",
 		"j_bloodstone",
 		"c_ouija",
-		"j_todo_list",
-		"j_baron",
-		"j_mime",
 	},
-	banned_jokers = {
-		"j_mp_speedrun",
+	banned_consumables = {
+		"c_justice",
 	},
-	banned_consumables = {},
 	reworked_jokers = {
 		"j_mp_hanging_chad",
 		"j_mp_ticket",
 		"j_mp_seltzer",
 		"j_mp_turtle_bean",
-		"j_mp_baron",
-		"j_mp_mime",
-		"j_mp_todo_list",
-		"j_mp_bloodstone",
 	},
 	reworked_consumables = {
 		"c_mp_ouija_standard",
 	},
 	reworked_enhancements = {
 		"m_mp_display_glass",
-		"m_mp_display_gold",
 	},
 })

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -953,10 +953,10 @@ return {
 			mp_sticker_balanced_j_mp_bloodstone = {
 				name = "Balanced",
 				text = {
-					"In {C:attention}PvP{}, the {C:green}1 in 2{} chance",
-					"rolls from a {C:attention}shared sequence{}",
-					"so both players see the {X:mult,C:white} X1.5 {}",
-					"trigger on the {C:attention}same{} hands",
+					"In {C:attention}PvP{}, the {C:green}1 in 2{} rolls",
+					"come from a {C:attention}fixed sequence{}",
+					"shared between both players and",
+					"{C:attention}reused{} every hand of the round",
 				},
 			},
 			mp_sticker_balanced_c_mp_ouija_standard = {
@@ -1312,6 +1312,8 @@ return {
 			k_vanilla_description = "The original Balatro experience.\n\nNo Multiplayer jokers, no balance changes.\nJust the base game as it was designed.\n\nMultiplayer features like the timer are still available\nbut can be disabled in Lobby Options.",
 			k_blitz = "Standard",
 			k_blitz_description = "The balanced Multiplayer ruleset.\n\nIncludes Multiplayer jokers and balance changes\nwith full control over your lobby settings.\n\n(See bans and reworks tabs for details)",
+			k_experimental = "Experimental",
+			k_experimental_description = "Standard's bleeding edge.\n\nHeavier balance changes being trialed\nfor a future Standard ruleset.\nExpect things to shift between versions.\n\n(See bans and reworks tabs for details)",
 			k_traditional = "Traditional",
 			k_traditional_description = "Multiplayer content without time pressure.\n\nIncludes Multiplayer jokers and balance changes,\nbut removes time-based mechanics for methodical play.\n\nTime-based jokers are banned.\nTimer is disabled.\n\n(See bans and reworks tabs for details)",
 			k_majorleague = "Major League",

--- a/objects/consumables/ouija.lua
+++ b/objects/consumables/ouija.lua
@@ -14,9 +14,6 @@ SMODS.Consumable({
 	unlocked = true,
 	discovered = true,
 	config = { extra = { destroy = 3 }, mp_sticker_balanced = true },
-	in_pool = function(self)
-		return MP.is_layer_active("sandbox") or MP.is_layer_active("standard")
-	end,
 	loc_vars = function(self, info_queue, card)
 		return { vars = { card.ability.extra.destroy } }
 	end,

--- a/objects/consumables/sandbox/ectoplasm.lua
+++ b/objects/consumables/sandbox/ectoplasm.lua
@@ -8,9 +8,6 @@ SMODS.Consumable({
 		info_queue[#info_queue + 1] = G.P_CENTERS.e_negative
 		return { vars = { G.GAME.ecto_minus or 1 } }
 	end,
-	in_pool = function(self)
-		return MP.is_layer_active("sandbox")
-	end,
 	use = function(self, card, area, copier)
 		local editionless_jokers = SMODS.Edition:get_edition_cards(G.jokers, true)
 		G.E_MANAGER:add_event(Event({

--- a/objects/jokers/standard/ticket.lua
+++ b/objects/jokers/standard/ticket.lua
@@ -7,7 +7,7 @@ SMODS.Joker({
 	rarity = 2,
 	cost = 6,
 	pos = { x = 5, y = 3 },
-	config = { extra = { dollars = 4 }, mp_balanced = true },
+	config = { extra = { dollars = 3 }, mp_balanced = true },
 	loc_vars = function(self, info_queue, card)
 		info_queue[#info_queue + 1] = G.P_CENTERS.m_gold
 		return { vars = { card.ability.extra.dollars } }

--- a/rulesets/_rulesets.lua
+++ b/rulesets/_rulesets.lua
@@ -280,5 +280,6 @@ function MP.LoadReworks(ruleset, key)
 				end
 			end
 		end
+		MP.LogLoadedPool()
 	end
 end

--- a/rulesets/_rulesets.lua
+++ b/rulesets/_rulesets.lua
@@ -32,8 +32,7 @@ local RulesetBase = SMODS.GameObject:extend({
 	create_info_menu = function(self)
 		local gamemode_text = nil
 		if self.forced_gamemode then
-			gamemode_text = self.forced_gamemode_text
-				or ("k_" .. self.forced_gamemode:gsub("gamemode_mp_", ""))
+			gamemode_text = self.forced_gamemode_text or ("k_" .. self.forced_gamemode:gsub("gamemode_mp_", ""))
 		end
 		local raw_key = self.key:gsub("^ruleset_mp_", "")
 		return MP.UI.CreateRulesetInfoMenu({
@@ -94,9 +93,7 @@ function MP.get_active_gamemode()
 		return MP.LOBBY.config.gamemode
 	elseif MP.is_practice_mode() then
 		-- Ghost replay stores the gamemode directly
-		if MP.GHOST.is_active() and MP.GHOST.gamemode then
-			return MP.GHOST.gamemode
-		end
+		if MP.GHOST.is_active() and MP.GHOST.gamemode then return MP.GHOST.gamemode end
 		local ruleset_key = MP.SP and MP.SP.ruleset
 		if ruleset_key and MP.Rulesets[ruleset_key] then return MP.Rulesets[ruleset_key].forced_gamemode end
 	end
@@ -268,18 +265,13 @@ function MP.LoadReworks(ruleset, key)
 			for k, v in pairs(tbl) do
 				if v.mp_reworks then
 					-- Always reset to vanilla first
-					if v.mp_reworks["vanilla"] then
-						process(k, "mp_vanilla_", tbl)
-					end
+					if v.mp_reworks["vanilla"] then process(k, "mp_vanilla_", tbl) end
 					-- Apply layers in order, then self
 					for _, layer in ipairs(resolution) do
-						if v.mp_reworks[layer] then
-							process(k, "mp_" .. layer .. "_", tbl)
-						end
+						if v.mp_reworks[layer] then process(k, "mp_" .. layer .. "_", tbl) end
 					end
 				end
 			end
 		end
-		MP.LogLoadedPool()
 	end
 end

--- a/rulesets/experimental.lua
+++ b/rulesets/experimental.lua
@@ -1,0 +1,5 @@
+MP.Ruleset({
+	key = "experimental",
+	layers = { "experimental", "ranked", "pressure_timer" },
+	forced_gamemode = "gamemode_mp_attrition",
+}):inject()

--- a/rulesets/ranked.lua
+++ b/rulesets/ranked.lua
@@ -1,5 +1,5 @@
 MP.Ruleset({
 	key = "standard_ranked",
-	layers = { "standard", "ranked", "pressure_timer" },
+	layers = { "standard", "ranked", "no_animation_timer" },
 	forced_gamemode = "gamemode_mp_attrition",
 }):inject()

--- a/tests/ruleset_shape.snapshot.lua
+++ b/tests/ruleset_shape.snapshot.lua
@@ -107,6 +107,7 @@ return {
       "m_mp_display_glass",
     },
     ["reworked_jokers"] = {
+      "j_mp_bloodstone",
       "j_mp_hanging_chad",
       "j_mp_seltzer",
       "j_mp_ticket",
@@ -172,6 +173,7 @@ return {
     ["reworked_jokers"] = {
       "j_mp_alloy_sandbox",
       "j_mp_ambrosia_sandbox",
+      "j_mp_bloodstone",
       "j_mp_bobby_sandbox",
       "j_mp_candynecklace_sandbox",
       "j_mp_chainlightning_sandbox",
@@ -226,6 +228,57 @@ return {
     ["reworked_vouchers"] = {},
     ["standard"] = true,
   },
+  ["experimental"] = {
+    ["_has_functions"] = {
+      ["create_info_menu"] = true,
+      ["force_lobby_options"] = true,
+      ["is_disabled"] = true,
+    },
+    ["banned_blinds"] = {},
+    ["banned_consumables"] = {},
+    ["banned_enhancements"] = {},
+    ["banned_jokers"] = {
+      "j_mp_speedrun",
+    },
+    ["banned_silent"] = {
+      "c_ouija",
+      "j_baron",
+      "j_bloodstone",
+      "j_hanging_chad",
+      "j_mime",
+      "j_selzer",
+      "j_ticket",
+      "j_todo_list",
+      "j_turtle_bean",
+    },
+    ["banned_tags"] = {},
+    ["banned_vouchers"] = {},
+    ["forced_gamemode"] = "gamemode_mp_attrition",
+    ["forced_lobby_options"] = true,
+    ["key"] = "experimental",
+    ["multiplayer_content"] = true,
+    ["reworked_blinds"] = {},
+    ["reworked_consumables"] = {
+      "c_mp_ouija_standard",
+    },
+    ["reworked_enhancements"] = {
+      "m_mp_display_glass",
+      "m_mp_display_gold",
+    },
+    ["reworked_jokers"] = {
+      "j_mp_baron",
+      "j_mp_bloodstone",
+      "j_mp_hanging_chad",
+      "j_mp_mime",
+      "j_mp_seltzer",
+      "j_mp_ticket",
+      "j_mp_todo_list",
+      "j_mp_turtle_bean",
+    },
+    ["reworked_tags"] = {},
+    ["reworked_vouchers"] = {},
+    ["standard"] = true,
+  },
   ["legacy_ranked"] = {
     ["_has_functions"] = {
       ["create_info_menu"] = true,
@@ -236,7 +289,9 @@ return {
     ["banned_consumables"] = {},
     ["banned_enhancements"] = {},
     ["banned_jokers"] = {},
-    ["banned_silent"] = {},
+    ["banned_silent"] = {
+      "j_hanging_chad",
+    },
     ["banned_tags"] = {},
     ["banned_vouchers"] = {},
     ["forced_gamemode"] = "gamemode_mp_attrition",
@@ -248,7 +303,9 @@ return {
     ["reworked_enhancements"] = {
       "m_mp_display_glass",
     },
-    ["reworked_jokers"] = {},
+    ["reworked_jokers"] = {
+      "j_mp_hanging_chad",
+    },
     ["reworked_tags"] = {},
     ["reworked_vouchers"] = {},
   },
@@ -427,6 +484,7 @@ return {
       "m_mp_display_glass",
     },
     ["reworked_jokers"] = {
+      "j_mp_bloodstone",
       "j_mp_hanging_chad",
       "j_mp_seltzer",
       "j_mp_ticket",
@@ -469,6 +527,7 @@ return {
       "m_mp_display_glass",
     },
     ["reworked_jokers"] = {
+      "j_mp_bloodstone",
       "j_mp_hanging_chad",
       "j_mp_seltzer",
       "j_mp_ticket",
@@ -512,6 +571,7 @@ return {
       "m_mp_display_glass",
     },
     ["reworked_jokers"] = {
+      "j_mp_bloodstone",
       "j_mp_hanging_chad",
       "j_mp_seltzer",
       "j_mp_ticket",
@@ -556,6 +616,7 @@ return {
       "m_mp_display_glass",
     },
     ["reworked_jokers"] = {
+      "j_mp_bloodstone",
       "j_mp_hanging_chad",
       "j_mp_seltzer",
       "j_mp_ticket",

--- a/tests/test_ruleset_shape.lua
+++ b/tests/test_ruleset_shape.lua
@@ -38,7 +38,13 @@ SMODS = {
 	},
 	process_loc_text = function() end,
 	Mods = {},
+	-- Stubs for the register-grafts in layers/_layers.lua. The real SMODS classes
+	-- have a :register() method; the layer code stores the original and wraps it.
+	Joker = { register = function(self) return self end },
+	Consumable = { register = function(self) return self end },
 }
+
+function sendDebugMessage() end
 
 G = {
 	P_CENTER_POOLS = { Ruleset = {} },

--- a/ui/main_menu/play_button/ruleset_selection.lua
+++ b/ui/main_menu/play_button/ruleset_selection.lua
@@ -37,6 +37,7 @@ function G.UIDEF.ruleset_selection_options(mode)
 			name = "k_custom",
 			buttons = {
 				{ button_id = "blitz_ruleset_button", button_localize_key = "k_blitz" },
+				{ button_id = "experimental_ruleset_button", button_localize_key = "k_experimental" },
 				{ button_id = "traditional_ruleset_button", button_localize_key = "k_traditional" },
 				{ button_id = "vanilla_ruleset_button", button_localize_key = "k_vanilla" },
 				{ button_id = "badlatro_ruleset_button", button_localize_key = "k_badlatro" },


### PR DESCRIPTION
## Summary

Sets up experimental ruleset infrastructure.

- **Standard** is just regular standard.
- **Experimental** ruleset added under Custom with experimental 0.4.0 changes, worn ranked-shaped — forced Attrition, locked lobby, `experimental + ranked + pressure_timer`.
- **Bloodstone** still listed under standard's reworks despite the demotion — the auto-gate would otherwise drop it (vanilla is silent-banned, MP variant qualifies only via layer membership).
- **Standard Ranked** gets new `no_animation_timer`.
- **Auto-gate extended to consumables** — `reworked_consumables` membership now stitches a default `mp_include` onto the center, mirror of the joker graft. Hand-rolled `in_pool` blocks dropped from ouija and sandbox ectoplasm.
- Test stubs updated for the new register-grafts.