### PR TITLE
Sandbox: soft lobby defaults instead of hard lock

### DIFF
--- a/rulesets/sandbox.lua
+++ b/rulesets/sandbox.lua
@@ -8,6 +8,6 @@ MP.Ruleset({
 		MP.LOBBY.config.preview_disabled = true
 		MP.LOBBY.config.the_order = true
 		MP.LOBBY.config.starting_lives = 4
-		return true
+		return false
 	end,
 }):inject()


### PR DESCRIPTION
## Summary
- Sandbox `force_lobby_options` now returns `false`, so its preview/order/lives values seed as defaults rather than locking the lobby.
- Hosts can now play sandbox with whatever lobby settings they want.

## Test plan
- [ ] Create a sandbox lobby; verify preview disabled, the_order on, 4 starting lives are pre-filled.
- [ ] Confirm host can toggle each of those settings off/change values without being reverted.