### PR TITLE
Warn dev-build players that they are, in fact, on a dev build

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -65,6 +65,7 @@ MP.EXPERIMENTAL = {
 	use_new_networking = true,
 	show_sandbox_collection = false,
 	alt_stakes = false,
+	suppress_dev_warning = false,
 }
 
 -- Override experimental flags from .env file if present

--- a/ui/main_menu/dev_warning.lua
+++ b/ui/main_menu/dev_warning.lua
@@ -1,0 +1,74 @@
+function G.FUNCS.mp_open_install_docs(e)
+	love.system.openURL("https://balatromp.com/docs/getting-started/installation")
+end
+
+function MP.UI.show_dev_build_warning()
+	if MP._dev_warning_shown then return end
+	if MP.EXPERIMENTAL.suppress_dev_warning then return end
+
+	local version = SMODS.Mods["Multiplayer"].version or ""
+	if not version:match("~DEV$") then return end
+
+	MP._dev_warning_shown = true
+
+	G.SETTINGS.paused = true
+	G.FUNCS.overlay_menu({
+		definition = create_UIBox_generic_options({
+			no_back = true,
+			no_esc = true,
+			contents = {
+				MP.UI.UTILS.create_column({ align = "cm", padding = 0.15 }, {
+					MP.UI.UTILS.create_row({ align = "cm", padding = 0.1 }, {
+						MP.UI.UTILS.create_text_node("MULTIPLAYER", {
+							scale = 0.8,
+							colour = G.C.UI.TEXT_LIGHT,
+						}),
+					}),
+					MP.UI.UTILS.create_row({ align = "cm", padding = 0.05 }, {
+						MP.UI.UTILS.create_text_node("Hand of cards, off the workbench - " .. version, {
+							scale = 0.55,
+							colour = G.C.MULT,
+						}),
+					}),
+					MP.UI.UTILS.create_row({ align = "cm", padding = 0.04 }, {
+						MP.UI.UTILS.create_text_node("You're playing a dev build - jokers may misbehave.", {
+							scale = 0.4,
+							colour = G.C.UI.TEXT_LIGHT,
+						}),
+					}),
+					MP.UI.UTILS.create_row({ align = "cm", padding = 0.04 }, {
+						MP.UI.UTILS.create_text_node("Ranked is locked. You may desync your nemesis.", {
+							scale = 0.4,
+							colour = G.C.UI.TEXT_LIGHT,
+						}),
+					}),
+					MP.UI.UTILS.create_row({ align = "cm", padding = 0.04 }, {
+						MP.UI.UTILS.create_text_node("For a clean shuffle, get the launcher below.", {
+							scale = 0.4,
+							colour = G.C.UI.TEXT_LIGHT,
+						}),
+					}),
+					MP.UI.UTILS.create_row({ align = "cm", padding = 0.15 }, {
+						UIBox_button({
+							label = { "Grab the launcher" },
+							button = "mp_open_install_docs",
+							colour = HEX("72A5F2"),
+							minw = 4.2,
+							scale = 0.5,
+							col = true,
+						}),
+						MP.UI.UTILS.create_blank(0.25, 0.1),
+						UIBox_button({
+							label = { "OK, I'll risk it" },
+							button = "exit_overlay_menu",
+							colour = G.C.RED,
+							minw = 3.2,
+							scale = 0.5,
+							col = true,
+						}),
+					}),
+				}),
+			},
+		}),
+	})
+end

--- a/ui/main_menu/main_menu.lua
+++ b/ui/main_menu/main_menu.lua
@@ -5,6 +5,7 @@ function Game:main_menu(change_context)
 
 	Add_custom_multiplayer_cards(change_context)
 	Add_version_display()
+	MP.UI.show_dev_build_warning()
 
 	return ret
 end


### PR DESCRIPTION
Turns out unsuspecting players downloading `~DEV` builds leads to confused bug reports, ranked desyncs, and the eternal question: "wait, why doesn't this work?"

So now the main menu pops a one-shot overlay when the version ends in `~DEV`. Two buttons: a blue one that punts you to the launcher install docs, and a red "OK, I'll risk it" for the brave.

<img width="1552" height="1075" alt="image" src="https://github.com/user-attachments/assets/2139c654-ff9e-4038-9ad0-91f7188089e0" />

Devs who'd rather not see this every time can drop `suppress_dev_warning=true` in `.env` and carry on.

## Test plan
- [x] Launch with `Multiplayer.json` version ending in `~DEV` → popup appears once on first main-menu entry
- [x] Click "Grab the launcher" → opens https://balatromp.com/docs/getting-started/installation
- [x] Click "OK, I'll risk it" → dismisses
- [x] Return to main menu (e.g. exit a lobby) → popup does not reappear
- [x] Set `suppress_dev_warning=true` in `.env` → popup never appears
- [x] Strip `~DEV` from version → popup never appears