### PR TITLE
Drop dead display_glass/display_gold loc entries

### DIFF
--- a/localization/de.lua
+++ b/localization/de.lua
@@ -134,24 +134,6 @@ return {
 				},
 			},
 		},
-		Enhanced = {
-			m_mp_display_glass = {
-				name = "Glass Karte",
-				text = {
-					"{X:mult,C:white} X#1# {} Mult",
-					"{C:green}#2# in #3#{} Chance diese",
-					"Karte zu zerstören",
-				},
-			},
-			m_mp_sandbox_display_glass = {
-				name = "Glass Karte",
-				text = {
-					"{X:mult,C:white} X#1# {} Mult",
-					"{C:green}#2# in #3#{} Chance diese",
-					"Karte zu zerstören",
-				},
-			},
-		},
 		Other = {
 			current_nemesis = {
 				name = "Erzfeind",

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -792,30 +792,6 @@ return {
 			},
 		},
 		Enhanced = {
-			m_mp_display_glass = {
-				name = "Glass Card",
-				text = {
-					"{X:mult,C:white} X#1# {} Mult",
-					"{C:green}#2# in #3#{} chance to",
-					"destroy card",
-				},
-			},
-			m_mp_sandbox_display_glass = {
-				name = "Glass Card",
-				text = {
-					"{X:mult,C:white} X#1# {} Mult",
-					"{C:green}#2# in #3#{} chance to",
-					"destroy card",
-				},
-			},
-			m_mp_display_gold = {
-				name = "Gold Card",
-				text = {
-					"{C:money}$#1#{} if this card is",
-					"{C:attention}held in hand{}",
-					"at end of round",
-				},
-			},
 		},
 		Back = {
 			b_mp_cocktail = {
@@ -968,12 +944,6 @@ return {
 				},
 			},
 			mp_sticker_balanced_m_gold = {
-				name = "Balanced",
-				text = {
-					"Earns {C:money}$4{} instead of {C:money}$3{}",
-				},
-			},
-			mp_sticker_balanced_m_mp_display_gold = {
 				name = "Balanced",
 				text = {
 					"Earns {C:money}$4{} instead of {C:money}$3{}",

--- a/localization/es_419.lua
+++ b/localization/es_419.lua
@@ -407,24 +407,6 @@ return {
 				},
 			},
 		},
-		Enhanced = {
-			m_mp_display_glass = {
-				name = "Carta de vidrio",
-				text = {
-					"{X:mult,C:white} X#1# {} multi",
-					"{C:green}#2# en #3#{} probabilidades",
-					"de destruir la carta",
-				},
-			},
-			m_mp_sandbox_display_glass = {
-				name = "Carta de vidrio",
-				text = {
-					"{X:mult,C:white} X#1# {} multi",
-					"{C:green}#2# en #3#{} probabilidades",
-					"de destruir la carta",
-				},
-			},
-		},
 		Back = {
 			b_mp_cocktail = {
 				name = "Baraja Cóctel",

--- a/localization/es_ES.lua
+++ b/localization/es_ES.lua
@@ -134,24 +134,6 @@ return {
 				},
 			},
 		},
-		Enhanced = {
-			m_mp_display_glass = {
-				name = "Carta de vidrio",
-				text = {
-					"{X:mult,C:white} X#1# {} Multi",
-					"{C:green}#2# en #3#{} probabilidades de",
-					"destruir la carta",
-				},
-			},
-			m_mp_sandbox_display_glass = {
-				name = "Carta de vidrio",
-				text = {
-					"{X:mult,C:white} X#1# {} Multi",
-					"{C:green}#2# en #3#{} probabilidades de",
-					"destruir la carta",
-				},
-			},
-		},
 		Other = {
 			current_nemesis = {
 				name = "Némesis",

--- a/localization/fr.lua
+++ b/localization/fr.lua
@@ -138,24 +138,6 @@ return {
 				},
 			},
 		},
-		Enhanced = {
-			m_mp_display_glass = {
-				name = "Carte Verre",
-				text = {
-					"{X:mult,C:white} X#1# {} Multi",
-					"{C:green}#2# chance(s) sur #3#{} de",
-					"détruire la carte",
-				},
-			},
-			m_mp_sandbox_display_glass = {
-				name = "Carte Verre",
-				text = {
-					"{X:mult,C:white} X#1# {} Multi",
-					"{C:green}#2# chance(s) sur #3#{} de",
-					"détruire la carte",
-				},
-			},
-		},
 		Other = {
 			current_nemesis = {
 				name = "Némésis",

--- a/localization/it.lua
+++ b/localization/it.lua
@@ -351,24 +351,6 @@ return {
 				},
 			},
 		},
-		Enhanced = {
-			m_mp_display_glass = {
-				name = "Carta di vetro",
-				text = {
-					"{X:mult,C:white} X#1#{} Molt",
-					"{C:green}#2# probabilità su #3#{} di",
-					"distruggere la carta",
-				},
-			},
-			m_mp_sandbox_display_glass = {
-				name = "Carta di vetro",
-				text = {
-					"{X:mult,C:white} X#1#{} Molt",
-					"{C:green}#2# probabilità su #3#{} di",
-					"distruggere la carta",
-				},
-			},
-		},
 		Back = {
 			b_mp_cocktail = {
 				name = "Mazzo cocktail",

--- a/localization/ja.lua
+++ b/localization/ja.lua
@@ -371,24 +371,6 @@ return {
 				},
 			},
 		},
-		Enhanced = {
-			m_mp_display_glass = {
-				name = "グラスカード",
-				text = {
-					"倍率 {X:mult,C:white} X#1# {}",
-					"ただし、{C:green}#3#分の#2#{} の確率で",
-					"破壊されてしまう",
-				},
-			},
-			m_mp_sandbox_display_glass = {
-				name = "グラスカード",
-				text = {
-					"倍率 {X:mult,C:white} X#1# {}",
-					"ただし、{C:green}#3#分の#2#{} の確率で",
-					"破壊されてしまう",
-				},
-			},
-		},
 		Back = {
 			b_mp_cocktail = {
 				name = "カクテルデッキ",

--- a/localization/ko.lua
+++ b/localization/ko.lua
@@ -416,24 +416,6 @@ return {
 			},
 		},
 
-		Enhanced = {
-			m_mp_display_glass = {
-				name = "글래스 카드",
-				text = {
-					"{X:mult,C:white}X#1#{} 배수",
-					"{C:green}#2# / #3#{} 확률로",
-					"카드 파괴",
-				},
-			},
-			m_mp_sandbox_display_glass = {
-				name = "글래스 카드",
-				text = {
-					"{X:mult,C:white}X#1#{} 배수",
-					"{C:green}#2# / #3#{} 확률로",
-					"카드 파괴",
-				},
-			},
-		},
 
 		Back = {
 			b_mp_cocktail = {

--- a/localization/mi.lua
+++ b/localization/mi.lua
@@ -133,24 +133,6 @@ return {
 				},
 			},
 		},
-		Enhanced = {
-			m_mp_display_glass = {
-				name = "Kāri Karāhe",
-				text = {
-					"{X:mult,C:white} X#1# {} Rea",
-					"He {C:green}#2#/#3#{} te tūpono ka",
-					"pakaru te kāri",
-				},
-			},
-			m_mp_sandbox_display_glass = {
-				name = "Kāri Karāhe",
-				text = {
-					"{X:mult,C:white} X#1# {} Rea",
-					"He {C:green}#2#/#3#{} te tūpono ka",
-					"pakaru te kāri",
-				},
-			},
-		},
 		Other = {
 			current_nemesis = {
 				name = "Te Hoariri",

--- a/localization/nl.lua
+++ b/localization/nl.lua
@@ -137,24 +137,6 @@ return {
 				},
 			},
 		},
-		Enhanced = {
-			m_mp_display_glass = {
-				name = "Glazen Kaart",
-				text = {
-					"{X:mult,C:white} X#1# {} Multi",
-					"{C:green}#2# in #3#{} kans om",
-					"kaart te vernietigen",
-				},
-			},
-			m_mp_sandbox_display_glass = {
-				name = "Glazen Kaart",
-				text = {
-					"{X:mult,C:white} X#1# {} Multi",
-					"{C:green}#2# in #3#{} kans om",
-					"kaart te vernietigen",
-				},
-			},
-		},
 		Other = {
 			current_nemesis = {
 				name = "Aartsvijand",

--- a/localization/pl.lua
+++ b/localization/pl.lua
@@ -136,26 +136,6 @@ return {
 				},
 			},
 		},
-		Enhanced = {
-			m_mp_display_glass = {
-				name = "Szklany Joker",
-				text = {
-					"Ten joker zdobywa {X:mult,C:white} X#1# {}",
-					"do mnoż. za każdą zniszczoną",
-					"{C:attention}Kartę Szklaną",
-					"{C:inactive}(obecnie {X:mult,C:white} X#2# {C:inactive} do mnoż.)",
-				},
-			},
-			m_mp_sandbox_display_glass = {
-				name = "Szklany Joker",
-				text = {
-					"Ten joker zdobywa {X:mult,C:white} X#1# {}",
-					"do mnoż. za każdą zniszczoną",
-					"{C:attention}Kartę Szklaną",
-					"{C:inactive}(obecnie {X:mult,C:white} X#2# {C:inactive} do mnoż.)",
-				},
-			},
-		},
 		Back = {
 			b_mp_cocktail = {
 				name = "Koktajlowa talia",

--- a/localization/pt_BR.lua
+++ b/localization/pt_BR.lua
@@ -138,24 +138,6 @@ return {
 				},
 			},
 		},
-		Enhanced = {
-			m_mp_display_glass = {
-				name = "Carta de Vidro",
-				text = {
-					"{X:mult,C:white} X#1# {} Multi",
-					"Chance de {C:green}#2# em #3#{} de",
-					"destruir carta",
-				},
-			},
-			m_mp_sandbox_display_glass = {
-				name = "Carta de Vidro",
-				text = {
-					"{X:mult,C:white} X#1# {} Multi",
-					"Chance de {C:green}#2# em #3#{} de",
-					"destruir carta",
-				},
-			},
-		},
 		Back = {
 			b_mp_cocktail = {
 				name = "Baralho Coquetel",

--- a/localization/ru.lua
+++ b/localization/ru.lua
@@ -134,24 +134,6 @@ return {
 				},
 			},
 		},
-		Enhanced = {
-			m_mp_display_glass = {
-				name = "Стеклянная карта",
-				text = {
-					"{X:mult,C:white} X#1# {} множ.",
-					"Имеет шанс {C:green}#2# к #3#{},",
-					"что будет уничтожена",
-				},
-			},
-			m_mp_sandbox_display_glass = {
-				name = "Стеклянная карта",
-				text = {
-					"{X:mult,C:white} X#1# {} множ.",
-					"Имеет шанс {C:green}#2# к #3#{},",
-					"что будет уничтожена",
-				},
-			},
-		},
 		Other = {
 			current_nemesis = {
 				name = "Соперник",

--- a/localization/vi.lua
+++ b/localization/vi.lua
@@ -386,24 +386,6 @@ return {
 				},
 			},
 		},
-		Enhanced = {
-			m_mp_display_glass = {
-				name = "Lá Kính",
-				text = {
-					"{X:mult,C:white} X#1# {} Nhân",
-					"Xác suất {C:green}#2# trên #3#{}",
-					"để phá huỷ lá bài",
-				},
-			},
-			m_mp_sandbox_display_glass = {
-				name = "Lá Kính",
-				text = {
-					"{X:mult,C:white} X#1# {} Nhân",
-					"Xác suất {C:green}#2# trên #3#{}",
-					"để phá huỷ lá bài",
-				},
-			},
-		},
 		Back = {
 			b_mp_cocktail = {
 				name = "Bộ Bài Cocktail",

--- a/localization/zh_CN.lua
+++ b/localization/zh_CN.lua
@@ -161,24 +161,6 @@ return {
 				},
 			},
 		},
-		Enhanced = {
-			m_mp_display_glass = {
-				name = "玻璃牌",
-				text = {
-					"{X:mult,C:white}X#1#{}倍率",
-					"有{C:green}#2#/#3#{}几率",
-					"摧毁此牌",
-				},
-			},
-			m_mp_sandbox_display_glass = {
-				name = "玻璃牌",
-				text = {
-					"{X:mult,C:white}X#1#{}倍率",
-					"有{C:green}#2#/#3#{}几率",
-					"摧毁此牌",
-				},
-			},
-		},
 		Other = {
 			current_nemesis = {
 				name = "宿敌",

--- a/tests/ruleset_shape.snapshot.lua
+++ b/tests/ruleset_shape.snapshot.lua
@@ -104,7 +104,7 @@ return {
       "c_mp_ouija_standard",
     },
     ["reworked_enhancements"] = {
-      "m_mp_display_glass",
+      "m_glass",
     },
     ["reworked_jokers"] = {
       "j_mp_bloodstone",
@@ -167,8 +167,8 @@ return {
       "c_mp_ouija_standard",
     },
     ["reworked_enhancements"] = {
-      "m_mp_display_glass",
-      "m_mp_sandbox_display_glass",
+      "m_glass",
+      "m_glass",
     },
     ["reworked_jokers"] = {
       "j_mp_alloy_sandbox",
@@ -262,8 +262,8 @@ return {
       "c_mp_ouija_standard",
     },
     ["reworked_enhancements"] = {
-      "m_mp_display_glass",
-      "m_mp_display_gold",
+      "m_glass",
+      "m_gold",
     },
     ["reworked_jokers"] = {
       "j_mp_baron",
@@ -301,7 +301,7 @@ return {
     ["reworked_blinds"] = {},
     ["reworked_consumables"] = {},
     ["reworked_enhancements"] = {
-      "m_mp_display_glass",
+      "m_glass",
     },
     ["reworked_jokers"] = {
       "j_mp_hanging_chad",
@@ -398,7 +398,7 @@ return {
       "c_mp_ouija_standard",
     },
     ["reworked_enhancements"] = {
-      "m_mp_sandbox_display_glass",
+      "m_glass",
     },
     ["reworked_jokers"] = {
       "j_mp_alloy_sandbox",
@@ -481,7 +481,7 @@ return {
       "c_mp_ouija_standard",
     },
     ["reworked_enhancements"] = {
-      "m_mp_display_glass",
+      "m_glass",
     },
     ["reworked_jokers"] = {
       "j_mp_bloodstone",
@@ -524,7 +524,7 @@ return {
       "c_mp_ouija_standard",
     },
     ["reworked_enhancements"] = {
-      "m_mp_display_glass",
+      "m_glass",
     },
     ["reworked_jokers"] = {
       "j_mp_bloodstone",
@@ -568,7 +568,7 @@ return {
       "c_mp_ouija_standard",
     },
     ["reworked_enhancements"] = {
-      "m_mp_display_glass",
+      "m_glass",
     },
     ["reworked_jokers"] = {
       "j_mp_bloodstone",
@@ -613,7 +613,7 @@ return {
       "c_mp_ouija_standard",
     },
     ["reworked_enhancements"] = {
-      "m_mp_display_glass",
+      "m_glass",
     },
     ["reworked_jokers"] = {
       "j_mp_bloodstone",


### PR DESCRIPTION
## Summary
- Follow-up to #422. The dummy `m_mp_display_glass`, `m_mp_sandbox_display_glass`, and `m_mp_display_gold` enhancements were removed there, but their loc blocks stayed behind in 15 locale files and the ruleset shape snapshot still pinned the old keys.
- Removes the orphaned entries from every locale (and the en-us-only `mp_sticker_balanced_m_mp_display_gold` sticker), then regenerates `tests/ruleset_shape.snapshot.lua` so `reworked_enhancements` points at the real `m_glass` / `m_gold` ReworkCenter targets.

## Test plan
- [x] `lua tests/test_ruleset_shape.lua test` — 13/13 pass
- [x] `grep -r "display_glass\|m_mp_display_gold\|sticker_balanced_m_mp_display_gold" localization/` returns nothing
- [ ] Smoke-test in-game: open a Standard ruleset info panel and confirm Glass rework still renders correctly via the live `m_glass` entry