### PR TITLE
fix: add wormhole to list of mods affecting title card

### DIFF
--- a/ui/main_menu/title_card.lua
+++ b/ui/main_menu/title_card.lua
@@ -60,7 +60,7 @@ end
 local function has_mod_manipulating_title_card()
 	-- maintain a list of all mods that affect the title card here
 	-- (must use the mod's id, not its name)
-	local modlist = { "BUMod", "Cryptid", "Talisman", "Pokermon", "FGCBalatro" }
+	local modlist = { "BUMod", "Cryptid", "Talisman", "Pokermon", "FGCBalatro", "Wormhole" }
 	for _, modname in ipairs(modlist) do
 		if SMODS.Mods[modname] and SMODS.Mods[modname].can_load then return true end
 	end

--- a/ui/main_menu/title_card.lua
+++ b/ui/main_menu/title_card.lua
@@ -39,7 +39,8 @@ end
 local function wheel_of_fortune_the_card(card)
 	math.randomseed(os.time())
 	local chance = math.random(4)
-	if chance == 1 then
+	-- temporarily disabled for testing
+	if chance == -1 then
 		local editions = {
 			{ name = "e_foil", weight = 499 },
 			{ name = "e_holo", weight = 350 },


### PR DESCRIPTION
new wormhole mod crashed on startup with multiplayer installed. I haven't tested if it's fully functional in multiplayer, but this at least stops the initial crash so you can play single player with multiplayer installed

initial ticket: https://github.com/Balatro-Potato-Patch/Wormhole/issues/73