### PR TITLE
feat(ghost-replay): pull the 10 latest games from the Lovely log folder

### DIFF
--- a/lib/ghost_replay.lua
+++ b/lib/ghost_replay.lua
@@ -291,12 +291,6 @@ function MP.GHOST.build_label(r)
 	)
 end
 
--- Load ghost replays from .log and .json files in the replays/ folder.
--- Files are read once when the picker is opened; drop a Lovely log or
--- a .json file into replays/ and it shows up in the ghost replay picker.
-
--- Load a .json replay file — useful for verifying log parser output or
--- loading replays exported from external tools.
 local function load_json_replay(filepath, filename)
 	local json = require("json")
 	local content = NFS.read(filepath)
@@ -308,7 +302,6 @@ local function load_json_replay(filepath, filename)
 		return nil
 	end
 
-	-- Convert string ante keys to numbers for consistency
 	local fixed = {}
 	for k, v in pairs(replay.ante_snapshots) do
 		fixed[tonumber(k) or k] = v
@@ -317,6 +310,28 @@ local function load_json_replay(filepath, filename)
 	replay._source = "file"
 	replay._filename = filename
 	return replay
+end
+
+local function parse_log_into_replays(log_parser, content, filename, source)
+	local out = {}
+	if not (content and log_parser) then return out end
+	local ok, game_records = pcall(log_parser.process_log, content)
+	if not (ok and game_records) then
+		sendWarnMessage("Failed to parse log: " .. filename, "MULTIPLAYER")
+		return out
+	end
+	local total = #game_records
+	for idx, game in ipairs(game_records) do
+		local ok2, replay = pcall(log_parser.to_replay, game)
+		if ok2 and replay and replay.ante_snapshots and next(replay.ante_snapshots) then
+			replay._source = source
+			replay._filename = filename
+			replay._game_index = idx
+			replay._game_count = total
+			out[#out + 1] = replay
+		end
+	end
+	return out
 end
 
 function MP.GHOST.load_folder_replays()
@@ -330,25 +345,9 @@ function MP.GHOST.load_folder_replays()
 
 	for _, item in ipairs(items) do
 		if item.type == "file" and item.name:match("%.log$") then
-			local filepath = replays_dir .. "/" .. item.name
-			local content = NFS.read(filepath)
-			if content and log_parser then
-				local ok, game_records = pcall(log_parser.process_log, content)
-				if ok and game_records then
-					local total = #game_records
-					for idx, game in ipairs(game_records) do
-						local ok2, replay = pcall(log_parser.to_replay, game)
-						if ok2 and replay and replay.ante_snapshots and next(replay.ante_snapshots) then
-							replay._source = "file"
-							replay._filename = item.name
-							replay._game_index = idx
-							replay._game_count = total
-							table.insert(results, replay)
-						end
-					end
-				else
-					sendWarnMessage("Failed to parse log: " .. item.name, "MULTIPLAYER")
-				end
+			local content = NFS.read(replays_dir .. "/" .. item.name)
+			for _, replay in ipairs(parse_log_into_replays(log_parser, content, item.name, "file")) do
+				results[#results + 1] = replay
 			end
 		elseif item.type == "file" and item.name:match("%.json$") then
 			local replay = load_json_replay(replays_dir .. "/" .. item.name, item.name)
@@ -356,10 +355,56 @@ function MP.GHOST.load_folder_replays()
 		end
 	end
 
-	-- Sort by timestamp descending (newest first)
 	table.sort(results, function(a, b)
 		return (a.timestamp or 0) > (b.timestamp or 0)
 	end)
 
+	return results
+end
+
+-- NFS is nativefs — accepts absolute paths directly, no sandboxing.
+local function lovely_log_dir()
+	local ok, lovely = pcall(require, "lovely")
+	if not (ok and lovely and lovely.log_path) then return nil end
+	local dir = lovely.log_path:match("(.*)[/\\]")
+	if not dir or dir == "" then return nil end
+	return dir
+end
+
+-- A single .log file can contain multiple games; parse newest-first and stop once we hit `limit`.
+function MP.GHOST.load_lovely_log_replays(limit)
+	limit = limit or 10
+	local dir = lovely_log_dir()
+	if not dir then return {} end
+
+	local items = NFS.getDirectoryItemsInfo(dir)
+	if not items then return {} end
+	local logs = {}
+	for _, item in ipairs(items) do
+		if item.type == "file" and item.name:match("%.log$") then
+			logs[#logs + 1] = item
+		end
+	end
+	table.sort(logs, function(a, b)
+		return (a.modtime or 0) > (b.modtime or 0)
+	end)
+
+	local log_parser = MP.load_mp_file("lib/log_parser.lua")
+	local results = {}
+	for _, item in ipairs(logs) do
+		local content = NFS.read(dir .. "/" .. item.name)
+		for _, replay in ipairs(parse_log_into_replays(log_parser, content, item.name, "lovely_log")) do
+			results[#results + 1] = replay
+		end
+		if #results >= limit then break end
+	end
+
+	table.sort(results, function(a, b)
+		return (a.timestamp or 0) > (b.timestamp or 0)
+	end)
+
+	while #results > limit do
+		results[#results] = nil
+	end
 	return results
 end

--- a/lib/log_parser.lua
+++ b/lib/log_parser.lua
@@ -348,6 +348,9 @@ function LOG_PARSER.process_log(content)
 				end
 				game.nemesis_stats = stats
 
+			elseif action == "receiveEndGameJokers" then
+				if kv.seed then game.seed = tostring(kv.seed) end
+
 			elseif action == "stopGame" then
 				if kv.seed then game.seed = tostring(kv.seed) end
 				if ts then game.game_end_ts = ts end

--- a/ui/main_menu/play_button/ghost_replay_picker.lua
+++ b/ui/main_menu/play_button/ghost_replay_picker.lua
@@ -434,15 +434,23 @@ end
 -------------------------------------------------------------------------------
 
 function G.UIDEF.ghost_replay_picker()
-	-- Load replays from the replays/ folder, sorted newest-first
 	local all = MP.GHOST.load_folder_replays()
+	local seen = {}
+	for _, r in ipairs(all) do
+		seen[(r._filename or "") .. ":" .. (r._game_index or 0)] = true
+	end
+	for _, r in ipairs(MP.GHOST.load_lovely_log_replays(10)) do
+		local key = (r._filename or "") .. ":" .. (r._game_index or 0)
+		if not seen[key] then
+			seen[key] = true
+			all[#all + 1] = r
+		end
+	end
 
-	-- Sort newest-first
 	table.sort(all, function(a, b)
 		return (a.timestamp or 0) > (b.timestamp or 0)
 	end)
 
-	-- Stash for callbacks to index into
 	_picker_replays = all
 
 	-- Left column: replay list
@@ -470,7 +478,7 @@ function G.UIDEF.ghost_replay_picker()
 				{
 					n = G.UIT.T,
 					config = {
-						text = "Place .log or .json files in the replays/ folder",
+						text = "Play a match, or place .log/.json in replays/",
 						scale = 0.28,
 						colour = G.C.UI.TEXT_INACTIVE,
 					},


### PR DESCRIPTION
The ghost picker now reads the Lovely log directory directly — no more
hand-populating `replays/`. Nativefs on the dir derived from
`lovely.log_path`, newest-first, capped at 10. Merged with `replays/`,
deduped on `(_filename, _game_index)`.

Same trip, smaller fix: games that ended without a `stopGame` — crashes,
rage-quits, host-vanishes — had no seed, so the picker couldn't replay
the runs arguably most worth replaying. The seed is sitting in the
preceding `receiveEndGameJokers`. Take it from there.

### Test plan

- [x] Empty `replays/`, fresh install: picker lists ~10 recent sessions.
- [x] Kill the process mid-run: that session reappears with a usable seed.