### PR TITLE
Score Preview notaion and visual adjustments

### DIFF
--- a/compatibility/Preview/CorePreview.lua
+++ b/compatibility/Preview/CorePreview.lua
@@ -142,7 +142,7 @@ function G.FUNCS.fn_pre_score_UI_set(e)
 	local new_preview_text = ""
 	local should_juice = false
 	if FN.PRE.lock_updates then
-		if e.config.id == "fn_pre_l" then
+		if e.config.id == "fn_pre_m" then
 			new_preview_text = " " .. MP.UTILS.get_preview_cfg("text") .. " "
 			should_juice = true
 		end
@@ -150,8 +150,11 @@ function G.FUNCS.fn_pre_score_UI_set(e)
 		if FN.PRE.data then
 			if FN.PRE.show_preview and (FN.PRE.data.score.min ~= FN.PRE.data.score.max) then
 				-- Format as 'X - Y' :
-				if e.config.id == "fn_pre_l" then
-					new_preview_text = FN.PRE.format_number(FN.PRE.data.score.min) .. " - "
+				if e.config.id == "fn_pre_m" then
+                    new_preview_text = " - "
+					if FN.PRE.is_enough_to_win(FN.PRE.data.score.min) then should_juice = true end
+                elseif e.config.id == "fn_pre_l" then
+					new_preview_text = FN.PRE.format_number(FN.PRE.data.score.min)
 					if FN.PRE.is_enough_to_win(FN.PRE.data.score.min) then should_juice = true end
 				elseif e.config.id == "fn_pre_r" then
 					new_preview_text = FN.PRE.format_number(FN.PRE.data.score.max)
@@ -164,7 +167,7 @@ function G.FUNCS.fn_pre_score_UI_set(e)
 						-- Spaces around number necessary to distinguish Min/Max text from Exact text,
 						-- which is itself necessary to force a HUD update when switching between Min/Max and Exact.
 						if FN.PRE.show_preview then
-							new_preview_text = " " .. FN.PRE.format_number(FN.PRE.data.score.min) .. " "
+							new_preview_text = FN.PRE.format_number(FN.PRE.data.score.min)
 							if FN.PRE.is_enough_to_win(FN.PRE.data.score.min) then should_juice = true end
 						else
 							if FN.PRE.is_enough_to_win(FN.PRE.data.score.min) then
@@ -200,7 +203,12 @@ function G.FUNCS.fn_pre_score_UI_set(e)
 
 	if (not FN.PRE.text.score[e.config.id:sub(-1)]) or new_preview_text ~= FN.PRE.text.score[e.config.id:sub(-1)] then
 		FN.PRE.text.score[e.config.id:sub(-1)] = new_preview_text
+        e.config.object.scale = e.config.object.config.scale
 		e.config.object:update_text()
+        if e.config.object.config.maxw then
+            e.config.object.scale = e.config.object.config.scale * math.min(1, e.config.object.config.maxw/e.config.object.config.W)
+            e.config.object:update_text(true)
+        end
 		-- Wobble:
 		if not G.TAROT_INTERRUPT_PULSE then
 			if should_juice then
@@ -245,7 +253,12 @@ function G.FUNCS.fn_pre_dollars_UI_set(e)
 	if not FN.PRE.text.dollars[e.config.id:sub(-3)] or new_preview_text ~= FN.PRE.text.dollars[e.config.id:sub(-3)] then
 		FN.PRE.text.dollars[e.config.id:sub(-3)] = new_preview_text
 		e.config.object.colours = { new_colour }
+        e.config.object.scale = e.config.object.config.scale
 		e.config.object:update_text()
+        if e.config.object.config.maxw then
+            e.config.object.scale = e.config.object.config.scale * math.min(1, e.config.object.config.maxw/e.config.object.config.W)
+            e.config.object:update_text(true)
+        end
 		if not G.TAROT_INTERRUPT_PULSE then e.config.object:pulse(0.25) end
 	end
 end

--- a/compatibility/Preview/InitPreview.lua
+++ b/compatibility/Preview/InitPreview.lua
@@ -9,7 +9,7 @@ FN.PRE = {
         empty = true,
 	},
 	text = {
-		score = { l = "", r = "" },
+		score = { l = "", r = "", m = "" },
 		dollars = { top = "", bot = "" },
 	},
 	joker_order = {},

--- a/compatibility/Preview/InterfacePreview.lua
+++ b/compatibility/Preview/InterfacePreview.lua
@@ -45,6 +45,7 @@ function FN.PRE.get_calculate_score_button()
 			colour = G.C.RED,
 			hover = true,
 			shadow = true,
+            maxw = 4.5
 		},
 		nodes = {
 			{
@@ -76,7 +77,7 @@ function FN.PRE.get_score_node()
 
 	return {
 		n = G.UIT.C,
-		config = { id = "fn_pre_score", align = "cm" },
+		config = { id = "fn_pre_score", align = "cm", minh = 0.5 },
 		nodes = {
 			{
 				n = G.UIT.O,
@@ -89,6 +90,22 @@ function FN.PRE.get_score_node()
 						shadow = true,
 						float = true,
 						scale = text_scale,
+                        maxw = 2,
+					}),
+				},
+			},
+			{
+				n = G.UIT.O,
+				config = {
+					id = "fn_pre_m",
+					func = "fn_pre_score_UI_set",
+					object = DynaText({
+						string = { { ref_table = FN.PRE.text.score, ref_value = "m" } },
+						colours = { G.C.UI.TEXT_LIGHT },
+						shadow = true,
+						float = true,
+						scale = text_scale,
+                        maxw = 4,
 					}),
 				},
 			},
@@ -103,6 +120,7 @@ function FN.PRE.get_score_node()
 						shadow = true,
 						float = true,
 						scale = text_scale,
+                        maxw = 2,
 					}),
 				},
 			},

--- a/compatibility/Preview/UtilsPreview.lua
+++ b/compatibility/Preview/UtilsPreview.lua
@@ -13,12 +13,6 @@ end
 
 function FN.PRE.format_number(num)
 	if not num or type(num) ~= "number" then return num or "" end
-	-- Start using e-notation earlier to reduce number length, if showing min and max for preview:
-	if true and num >= 1e7 then
-		local x = string.format("%.4g", num)
-		local fac = math.floor(math.log(tonumber(x), 10))
-		return string.format("%.2f", x / (10 ^ fac)) .. "e" .. fac
-	end
 	return number_format(num) -- Default Balatro function.
 end
 


### PR DESCRIPTION
This PR makes score preview match vanilla display in terms of how many digits to show before switch to scientific notation.
To achieve this, some UI changes was made to make sure text length does not affect HUD UI by limiting it's width.

Additionally, added max width for text such as "Calculate" button and "Calculating..." label, in case of people want set very long one via changing mod config.

<img width="446" height="356" alt="Balatro_woY5bHf3RZ" src="https://github.com/user-attachments/assets/236b53d8-5ff3-4b4e-8210-df347a0c7c70" />
