### PR TITLE
replay load crash + alloy

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -37,7 +37,7 @@ MP.ACTIONS = {}
 MP.MOD_ACTIONS = {}
 
 -- SMODS flag: lets cards count as multiple enhancements at once (required by Alloy)
-MP.optional_features = { quantum_enhancements = true }
+MP.optional_features = { quantum_enhancements = false }
 
 function MP.register_mod_action(modAction, callback, modId)
 	if not modId then

--- a/layers/sandbox.lua
+++ b/layers/sandbox.lua
@@ -33,7 +33,7 @@ MP.SANDBOX.joker_mappings = {
 	{ sandbox = "j_mp_satellite_sandbox", vanilla = "j_satellite", active = false },
 
 	-- Extra Credit jokers
-	{ sandbox = "j_mp_alloy_sandbox", vanilla = nil, active = true, group = "extra_credit" },
+	-- { sandbox = "j_mp_alloy_sandbox", vanilla = nil, active = true, group = "extra_credit" },
 	{ sandbox = "j_mp_ambrosia_sandbox", vanilla = nil, active = true, group = "extra_credit" },
 	{ sandbox = "j_mp_bobby_sandbox", vanilla = nil, active = true, group = "extra_credit" },
 	{ sandbox = "j_mp_candynecklace_sandbox", vanilla = nil, active = true, group = "extra_credit" },

--- a/ui/main_menu/play_button/ruleset_selection.lua
+++ b/ui/main_menu/play_button/ruleset_selection.lua
@@ -124,7 +124,7 @@ function G.UIDEF.ruleset_selection_options(mode, buttons)
 	-- If ghost is active, preserve the replay's ruleset instead of resetting to default
 	local default_ruleset
 	if mode == "practice" and MP.GHOST.is_active() and MP.SP.ruleset then
-		default_ruleset = MP.SP.ruleset
+		default_ruleset = MP.SP.ruleset:gsub("^ruleset_mp_", "")
 	else
 		default_ruleset = string.match(buttons[1].buttons[1].button_id, "(.+)_ruleset_button$")
 	end


### PR DESCRIPTION
Strip the ruleset_mp_ prefix when restoring MP.SP.ruleset from a replay, so reopening the practice menu doesn’t double-prefix into a nil ruleset lookup.

Disable quantum_enhancements (slowdown city) and shelf the Alloy sandbox entry while the flag is off.