### PR TITLE
default-deny mp-prefixed cards in pool filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 
 - **To Do List** — Reworked. Now pays $5 (up from $4). Target poker hand is chosen from all hands, not just discovered ones.
 - **Golden Ticket** — Reverted payout nerf, now earns $4 (up from $3)
-- **Baron** and **Mime** — Swapped rarities. Baron is now Uncommon ($5), Mime is now Rare ($8).
 - **Speedrun** — Out of rotation.
 - **Ouija** and **Ectoplasm** — Now cost $4 (bug fix).
 

--- a/layers/_layers.lua
+++ b/layers/_layers.lua
@@ -32,6 +32,34 @@ local function layer_membership_include(owning_layers)
 	end
 end
 
+function MP.should_exclude_from_pool(v)
+	if v.mp_include and type(v.mp_include) == "function" then return not v:mp_include() end
+	-- User reports they got a joker that shouldn’t exist in their ruleset.
+	-- I check, confidently. Tell them no, that’s impossible, I disabled it.
+	-- Then I read my own code.
+	if v.key and (v.key:sub(1, 5) == "j_mp_" or v.key:sub(1, 5) == "c_mp_") then return true end
+	return false
+end
+
+-- After auto-gating, we warn if an MP-prefixed card still has no mp_include and
+-- isn't in any reworked_jokers list.
+local function warn_if_ungated(key, kind, prefix)
+	if key and key:sub(1, #prefix) == prefix then
+		sendDebugMessage(
+			"WARNING: "
+				.. kind
+				.. " "
+				.. key
+				.. " has no mp_include and is not in any reworked list. "
+				.. "Under default-deny it will be excluded from every ruleset's pool. "
+				.. "Either add the key to a layer/ruleset's reworked_"
+				.. kind
+				.. "s, or define an explicit mp_include.",
+			"MULTIPLAYER"
+		)
+	end
+end
+
 -- A small graft on SMODS.Joker:register. Any joker whose full key appears in some
 -- layer's reworked_jokers gets a default mp_include stitched on when none is
 -- provided. By the time register runs the key is already prefixed, so we can look
@@ -47,6 +75,7 @@ function SMODS.Joker:register()
 		)
 		self.mp_include = layer_membership_include(owning_layers)
 	end
+	if not self.mp_include then warn_if_ungated(self.key, "joker", "j_mp_") end
 	return _original_joker_register(self)
 end
 
@@ -63,6 +92,7 @@ function SMODS.Consumable:register()
 		)
 		self.mp_include = layer_membership_include(owning_layers)
 	end
+	if not self.mp_include then warn_if_ungated(self.key, "consumable", "c_mp_") end
 	return _original_consumable_register(self)
 end
 

--- a/lovely/misc.toml
+++ b/lovely/misc.toml
@@ -99,13 +99,15 @@ target = "functions/misc_functions.lua"
 pattern = '''if G.SETTINGS.paused and key ~= 'to_do' then return math.random() end'''
 position = "at"
 payload = '''
--- disabled by Multiplayer because of voucher rng calls while paused 
+-- disabled by Multiplayer because of voucher rng calls while paused
 -- if G.SETTINGS.paused and key ~= 'to_do' then return math.random() end
 '''
 match_indent = true
 
-# mp_exclude function
-# avoids UNAVAILABLE substitution for rng preservation
+# Pool exclusion hook for RNG-safe removal:
+# pop the just-added entry, but only decrement _pool_size when it was a real key
+# banned keys hit the 'UNAVAILABLE' branch and need their slot preserved so the pseudorandom pool
+# queue stays aligned across clients and versions
 # unfortunate timing but lua doesn't have continue, so this is an uninvasive patch
 [[patches]]
 [patches.pattern]
@@ -116,12 +118,10 @@ end
 '''
 position = "after"
 payload = '''
-if v.mp_include and type(v.mp_include) == 'function' then
-	if not v:mp_include() then
-		table.remove(_pool) -- remove whatever was just done
-		if add and not G.GAME.banned_keys[v.key] then
-			_pool_size = _pool_size - 1
-		end
+if MP.should_exclude_from_pool(v) then
+	table.remove(_pool) -- remove whatever was just done
+	if add and not G.GAME.banned_keys[v.key] then
+		_pool_size = _pool_size - 1
 	end
 end
 '''

--- a/objects/jokers/experimental/baron_uncommon.lua
+++ b/objects/jokers/experimental/baron_uncommon.lua
@@ -1,3 +1,4 @@
+--[[
 SMODS.Joker({
 	key = "baron",
 	no_collection = true,
@@ -12,7 +13,12 @@ SMODS.Joker({
 		return { vars = { card.ability.extra.xmult } }
 	end,
 	calculate = function(self, card, context)
-		if context.individual and context.cardarea == G.hand and not context.end_of_round and context.other_card:get_id() == 13 then
+		if
+			context.individual
+			and context.cardarea == G.hand
+			and not context.end_of_round
+			and context.other_card:get_id() == 13
+		then
 			if context.other_card.debuff then
 				return {
 					message = localize("k_debuffed"),
@@ -26,3 +32,4 @@ SMODS.Joker({
 		end
 	end,
 })
+--]]

--- a/objects/jokers/experimental/mime_rare.lua
+++ b/objects/jokers/experimental/mime_rare.lua
@@ -1,3 +1,4 @@
+--[[
 SMODS.Joker({
 	key = "mime",
 	no_collection = true,
@@ -16,3 +17,4 @@ SMODS.Joker({
 		end
 	end,
 })
+--]]


### PR DESCRIPTION
## Summary

User reported uncommon baron's and rare mime's in experimental. No way I said, shouldn't happen. I checked, confidently. Then I read my own code. They were appearing in _every_ ruleset, in fact.

Nothing weird with that, default smods behavior is `in_pool = true`. But a bit scary.

- Flip pool filter to default-deny for `j_mp_*` / `c_mp_*` keys without an `mp_include` or `reworked_*` entry.
- Extract the decision into `MP.should_exclude_from_pool`; lovely patch shrinks to a call site + the existing RNG-safe removal.
- Log a `[MULTIPLAYER] WARNING:` at register time for any ungated mp-prefixed card.
- Comment out the experimental Baron/Mime reworks and drop them from `CHANGELOG.md`.

## Test plan

- [ ] Boot. Expect auto-gating lines, zero WARNINGs.
- [ ] Uncomment Baron. Expect one WARNING and absence from every pool.
- [ ] Wire Baron into `experimental.reworked_jokers`. WARNING goes away, appears in experimental shops only.