### PR TITLE
auto-gate tag_mp_* via reworked_tags, default-deny the prefix

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -227,8 +227,8 @@ Registration stores properties as `mp_<layer>_<prop>` on the center. `MP.LoadRew
 
 ### Wiring: when the layer entry is enough vs. when you need more
 
-- **Path A jokers / consumables** (`reworked_jokers`, `reworked_consumables`): the layer entry *does* drive runtime gating — auto-mp_include kicks in. You still write the `SMODS.Joker`/`SMODS.Consumable` definition and the `banned_silent` entry for the vanilla version, but no manual `mp_include` is needed for layer-only gates.
-- **Path B centers** (`reworked_enhancements`, `reworked_vouchers`, `reworked_tags`, `reworked_blinds`): the layer entry is **display metadata only**. Runtime patching needs a separate `MP.ReworkCenter(key, { layers = "..." })` call. Auto-gating doesn't apply because Path B doesn't go through `register`.
+- **Path A jokers / consumables / tags** (`reworked_jokers`, `reworked_consumables`, `reworked_tags`): the layer entry *does* drive runtime gating — auto-mp_include kicks in. You still write the `SMODS.Joker`/`SMODS.Consumable`/`SMODS.Tag` definition and the `banned_silent` entry for the vanilla version (if reskinning one), but no manual `mp_include` or `in_pool` is needed for layer-only gates. `tag_mp_*` is default-deny: a tag must be listed in some layer's `reworked_tags` (or define its own `mp_include`) to appear anywhere.
+- **Path B centers** (`reworked_enhancements`, `reworked_vouchers`, `reworked_blinds`): the layer entry is **display metadata only**. Runtime patching needs a separate `MP.ReworkCenter(key, { layers = "..." })` call. Auto-gating doesn't apply because Path B doesn't go through `register`.
 
 ### Ruleset Details
 

--- a/layers/_layers.lua
+++ b/layers/_layers.lua
@@ -5,6 +5,7 @@ MP.Layers = {}
 -- so the object file doesn't have to repeat what the layer already declared.
 MP._JOKER_LAYERS = {}
 MP._CONSUMABLE_LAYERS = {}
+MP._TAG_LAYERS = {}
 
 function MP.Layer(name, definition)
 	MP.Layers[name] = definition
@@ -18,6 +19,12 @@ function MP.Layer(name, definition)
 		for _, consumable_key in ipairs(definition.reworked_consumables) do
 			MP._CONSUMABLE_LAYERS[consumable_key] = MP._CONSUMABLE_LAYERS[consumable_key] or {}
 			table.insert(MP._CONSUMABLE_LAYERS[consumable_key], name)
+		end
+	end
+	if definition.reworked_tags then
+		for _, tag_key in ipairs(definition.reworked_tags) do
+			MP._TAG_LAYERS[tag_key] = MP._TAG_LAYERS[tag_key] or {}
+			table.insert(MP._TAG_LAYERS[tag_key], name)
 		end
 	end
 end
@@ -37,7 +44,7 @@ function MP.should_exclude_from_pool(v)
 	-- User reports they got a joker that shouldn’t exist in their ruleset.
 	-- I check, confidently. Tell them no, that’s impossible, I disabled it.
 	-- Then I read my own code.
-	if v.key and (v.key:sub(1, 5) == "j_mp_" or v.key:sub(1, 5) == "c_mp_") then return true end
+	if v.key and v.key:match("^%a+_mp_") then return true end
 	return false
 end
 
@@ -94,6 +101,24 @@ function SMODS.Consumable:register()
 	end
 	if not self.mp_include then warn_if_ungated(self.key, "consumable", "c_mp_") end
 	return _original_consumable_register(self)
+end
+
+-- Same graft for tags. Tags also flow through get_current_pool, so mp_include
+-- gates them too. The default-deny on tag_mp_* in should_exclude_from_pool means
+-- a tag must be listed in some layer's reworked_tags (or define its own
+-- mp_include) to appear in any ruleset's pool.
+local _original_tag_register = SMODS.Tag.register
+function SMODS.Tag:register()
+	if not self.mp_include and MP._TAG_LAYERS[self.key] then
+		local owning_layers = MP._TAG_LAYERS[self.key]
+		sendDebugMessage(
+			"Auto-gating " .. self.key .. " on layers: " .. table.concat(owning_layers, ", "),
+			"MULTIPLAYER"
+		)
+		self.mp_include = layer_membership_include(owning_layers)
+	end
+	if not self.mp_include then warn_if_ungated(self.key, "tag", "tag_mp_") end
+	return _original_tag_register(self)
 end
 
 -- Array-valued fields that get merged (layer base + ruleset additions)

--- a/objects/tags/gambling_sandbox.lua
+++ b/objects/tags/gambling_sandbox.lua
@@ -13,9 +13,6 @@ SMODS.Tag({
 	dependencies = {
 		items = {},
 	},
-	in_pool = function(self)
-		return MP.is_layer_active("sandbox")
-	end,
 	name = "Gambling Tag",
 	discovered = true,
 	min_ante = 2, -- less degeneracy

--- a/objects/tags/investment_sandbox.lua
+++ b/objects/tags/investment_sandbox.lua
@@ -30,7 +30,4 @@ SMODS.Tag({
 	unlocked = true,
 	discovered = true,
 	no_collection = MP.sandbox_no_collection,
-	in_pool = function(self)
-		return MP.is_layer_active("sandbox")
-	end,
 })

--- a/objects/tags/juggle_sandbox.lua
+++ b/objects/tags/juggle_sandbox.lua
@@ -20,7 +20,4 @@ SMODS.Tag({
 	unlocked = true,
 	discovered = true,
 	no_collection = MP.sandbox_no_collection,
-	in_pool = function(self)
-		return MP.is_layer_active("sandbox")
-	end,
 })

--- a/tests/test_ruleset_shape.lua
+++ b/tests/test_ruleset_shape.lua
@@ -42,6 +42,7 @@ SMODS = {
 	-- have a :register() method; the layer code stores the original and wraps it.
 	Joker = { register = function(self) return self end },
 	Consumable = { register = function(self) return self end },
+	Tag = { register = function(self) return self end },
 }
 
 function sendDebugMessage() end


### PR DESCRIPTION
Tags now get the same mp_include layer auto-gating as jokers and consumables — listing a tag in a layer's reworked_tags stitches on an mp_include that returns true iff any owning layer is active. tag_mp_* keys are default-denied from every pool unless gated, so tags can no longer leak across rulesets. Pool-prefix check collapsed to one pattern (^%a+_mp_) so future center types are covered for free.