### PR TITLE
refactor(experimental): drop m_gold rework, bump ante scaling

### DIFF
--- a/layers/experimental.lua
+++ b/layers/experimental.lua
@@ -32,9 +32,9 @@ MP.Layer("experimental", {
 	},
 	reworked_enhancements = {
 		"m_glass",
-		"m_gold",
 	},
 	on_apply_bans = function()
 		change_shop_size(1)
+        G.GAME.starting_params.ante_scaling = 1.15
 	end,
 })

--- a/objects/enhancements/mp_gold.lua
+++ b/objects/enhancements/mp_gold.lua
@@ -1,4 +1,0 @@
-MP.ReworkCenter("m_gold", {
-	layers = "experimental",
-	config = { h_dollars = 4, mp_balanced = true },
-})


### PR DESCRIPTION
## Summary
- Remove `m_gold` ReworkCenter from the experimental layer (deletes `objects/enhancements/mp_gold.lua` and drops `"m_gold"` from `reworked_enhancements`).
- Add `G.GAME.starting_params.ante_scaling = 1.15` to the layer's `on_apply_bans` hook.

## Test plan
- [x] Start a run with the Experimental ruleset; verify gold cards behave like vanilla and ante scaling is at 1.15.