### PR TITLE
refactor(practice): fold toggles + replays + modifiers into Practice Options overlay

### DIFF
--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -1159,6 +1159,7 @@ return {
 			k_practice_collection_hint = "Psst... click a card and it's yours. No questions asked!",
 			k_unlimited_slots = "Unlimited Slots",
 			k_edition_cycling = "Edition Cycling (Q)",
+			k_practice_options = "Practice Options...",
 			b_join_lobby = "Join Lobby",
 			b_join_lobby_clipboard = "Join From Clipboard",
 			b_return_lobby = "Return to Lobby",

--- a/ui/main_menu/play_button/_modifiers_overlay.lua
+++ b/ui/main_menu/play_button/_modifiers_overlay.lua
@@ -103,9 +103,11 @@ G.FUNCS.mp_open_modifiers_overlay = function(e)
 		}
 	end
 
+	local back_func = MP.is_practice_mode() and "mp_open_practice_options_overlay" or "create_lobby"
+
 	G.FUNCS.overlay_menu({
 		definition = create_UIBox_generic_options({
-			back_func = "create_lobby",
+			back_func = back_func,
 			contents = {
 				{
 					n = G.UIT.R,

--- a/ui/main_menu/play_button/_practice_options_overlay.lua
+++ b/ui/main_menu/play_button/_practice_options_overlay.lua
@@ -1,0 +1,83 @@
+-- Practice Options overlay: toggles, replay picker entry, and (when allowed by
+-- the ruleset) the Modifiers entry. Consolidated here so the ruleset_info panel
+-- in practice mode keeps to a tidy two-button action row.
+
+G.FUNCS.mp_practice_options_back = function(e)
+	G.FUNCS.overlay_menu({
+		definition = G.UIDEF.ruleset_selection_tabs("practice"),
+	})
+end
+
+G.FUNCS.mp_open_practice_options_overlay = function(e)
+	local ruleset = MP.SP.ruleset and MP.Rulesets[MP.SP.ruleset] or nil
+
+	local practice_toggles = {
+		{ id = "unlimited_slots_toggle", label = "k_unlimited_slots", ref_value = "unlimited_slots" },
+		{ id = "edition_cycling_toggle", label = "k_edition_cycling", ref_value = "edition_cycling" },
+	}
+	local toggle_nodes = {}
+	for _, t in ipairs(practice_toggles) do
+		toggle_nodes[#toggle_nodes + 1] = {
+			n = G.UIT.R,
+			config = { align = "cm", padding = 0.05 },
+			nodes = {
+				create_toggle({
+					id = t.id,
+					label = localize(t.label),
+					ref_table = MP.SP,
+					ref_value = t.ref_value,
+				}),
+			},
+		}
+	end
+
+	local ghost_label = localize("k_ghost_replays")
+	if MP.GHOST.is_active() then ghost_label = ghost_label .. " (Active)" end
+	local ghost_button = UIBox_button({
+		id = "ghost_replay_button",
+		button = "open_ghost_replay_picker",
+		label = { ghost_label },
+		minw = 4,
+		minh = 0.6,
+		scale = 0.4,
+		colour = MP.GHOST.is_active() and G.C.GREEN or G.C.BLUE,
+		hover = true,
+		shadow = true,
+	})
+
+	local body_rows = {
+		{
+			n = G.UIT.R,
+			config = { align = "cm", padding = 0.1 },
+			nodes = toggle_nodes,
+		},
+	}
+
+	local modifier_btn = ruleset and MP.UI.build_modifier_button(ruleset, "practice") or nil
+	if modifier_btn then
+		body_rows[#body_rows + 1] = {
+			n = G.UIT.R,
+			config = { align = "cm", padding = 0.15 },
+			nodes = { modifier_btn },
+		}
+	end
+
+	body_rows[#body_rows + 1] = {
+		n = G.UIT.R,
+		config = { align = "cm", padding = 0.15 },
+		nodes = { ghost_button },
+	}
+
+	G.FUNCS.overlay_menu({
+		definition = create_UIBox_generic_options({
+			back_func = "mp_practice_options_back",
+			contents = {
+				{
+					n = G.UIT.R,
+					config = { align = "cm", padding = 0.25, colour = G.C.BLACK, r = 0.25, minw = 6 },
+					nodes = body_rows,
+				},
+			},
+		}),
+	})
+end

--- a/ui/main_menu/play_button/ruleset_selection.lua
+++ b/ui/main_menu/play_button/ruleset_selection.lua
@@ -203,48 +203,6 @@ function G.UIDEF.ruleset_info(ruleset_name, mode)
 		},
 	}
 
-	if mode == "practice" then
-		local practice_toggles = {
-			{ id = "unlimited_slots_toggle", label = "k_unlimited_slots", ref_value = "unlimited_slots" },
-			{ id = "edition_cycling_toggle", label = "k_edition_cycling", ref_value = "edition_cycling" },
-		}
-		local toggle_nodes = {}
-		for _, t in ipairs(practice_toggles) do
-			toggle_nodes[#toggle_nodes + 1] = create_toggle({
-				id = t.id,
-				label = localize(t.label),
-				ref_table = MP.SP,
-				ref_value = t.ref_value,
-			})
-		end
-		content_nodes[#content_nodes + 1] = {
-			n = G.UIT.R,
-			config = { align = "cm", padding = 0.05 },
-			nodes = toggle_nodes,
-		}
-
-		-- Ghost replay picker button
-		local ghost_label = localize("k_ghost_replays")
-		if MP.GHOST.is_active() then ghost_label = ghost_label .. " (Active)" end
-		content_nodes[#content_nodes + 1] = {
-			n = G.UIT.R,
-			config = { align = "cm", padding = 0.05 },
-			nodes = {
-				UIBox_button({
-					id = "ghost_replay_button",
-					button = "open_ghost_replay_picker",
-					label = { ghost_label },
-					minw = 4,
-					minh = 0.6,
-					scale = 0.4,
-					colour = MP.GHOST.is_active() and G.C.GREEN or G.C.BLUE,
-					hover = true,
-					shadow = true,
-				}),
-			},
-		}
-	end
-
 	content_nodes[#content_nodes + 1] = MP.UI.build_action_row(ruleset, mode)
 
 	return {
@@ -736,6 +694,20 @@ function MP.UI.get_continue_button(ruleset, mode)
 	})
 end
 
+function MP.UI.build_practice_options_button()
+	return UIBox_button({
+		id = "practice_options_button",
+		button = "mp_open_practice_options_overlay",
+		label = { localize("k_practice_options") },
+		minw = 3.5,
+		minh = 0.8,
+		scale = 0.4,
+		colour = G.C.ORANGE,
+		hover = true,
+		shadow = true,
+	})
+end
+
 function MP.UI.build_action_row(ruleset, mode)
 	local columns = {}
 	local function add_col(button)
@@ -745,7 +717,11 @@ function MP.UI.build_action_row(ruleset, mode)
 			nodes = { button },
 		}
 	end
-	if mode == "mp" or mode == "practice" then
+	if mode == "practice" then
+		-- In practice, the Modifiers button is folded into Practice Options to
+		-- keep the action row to two buttons regardless of ruleset.
+		add_col(MP.UI.build_practice_options_button())
+	elseif mode == "mp" then
 		local modifier_btn = MP.UI.build_modifier_button(ruleset, mode)
 		if modifier_btn then add_col(modifier_btn) end
 	end


### PR DESCRIPTION
## Summary

Practice mode's ruleset_info panel stacked two toggles, a Match Replays button, and an action row into a fixed-height container. With Modifiers present, things clipped.

Toggles, Match Replays, and Modifiers now live behind a single `Practice Options...` button. Practice action row is always `[Practice Options...] [PLAY]`.

Also: Modifiers overlay's Back used to dump practice-mode users into MP create-lobby. Now it returns to Practice Options.