### PR TITLE
ui(ruleset-info): render {C:...} color tags in descriptions

### DIFF
--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -1333,7 +1333,7 @@ return {
 			k_legacy_ranked = "Legacy Ranked",
 			k_legacy_ranked_description = "A minimal competitive ruleset.\n\nNo Multiplayer cards or balance changes\nexcept Glass. Has locked settings:\n- Attrition gamemode\n- The Order enabled\n- Requires recommended Steamodded version",
 			k_experimental_standard = "Experimental (Standard)",
-			k_experimental_description = "Standard's bleeding edge.\n\nHeavier balance changes being trialed\nfor a future Standard ruleset.\n\nEach run rolls {C:attention}1/3{} on each of {C:attention}Persistent{}, {C:attention}Unreliable{}, {C:attention}Draining{}.\n\n(See bans and reworks tabs for details)",
+			k_experimental_description = "Standard's bleeding edge.\n\nHeavier balance changes being trialed\nfor a future Standard ruleset.\n\nEach run rolls {C:attention}1/3{} on each of {C:purple}Persistent{}, {C:green}Unreliable{}, {C:red}Draining{}.\n\n(See bans and reworks tabs for details)",
 			k_experimental_legacy = "Experimental (Classic)",
 			k_experimental_legacy_description = "An opinionated take on Legacy Ranked.\n\nGlass nerfed, Hanging Chad reworked, Justice banned,\nLet's Go Gambling.",
 			k_badlatro = "Badlatro",

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -1333,7 +1333,7 @@ return {
 			k_legacy_ranked = "Legacy Ranked",
 			k_legacy_ranked_description = "A minimal competitive ruleset.\n\nNo Multiplayer cards or balance changes\nexcept Glass. Has locked settings:\n- Attrition gamemode\n- The Order enabled\n- Requires recommended Steamodded version",
 			k_experimental_standard = "Experimental (Standard)",
-			k_experimental_description = "Standard's bleeding edge.\n\nHeavier balance changes being trialed\nfor a future Standard ruleset.\nExpect things to shift between versions.\n\n(See bans and reworks tabs for details)",
+			k_experimental_description = "Standard's bleeding edge.\n\nHeavier balance changes being trialed\nfor a future Standard ruleset.\n\nEach run rolls {C:attention}1/3{} on each of {C:attention}Persistent{}, {C:attention}Unreliable{}, {C:attention}Draining{}.\n\n(See bans and reworks tabs for details)",
 			k_experimental_legacy = "Experimental (Classic)",
 			k_experimental_legacy_description = "An opinionated take on Legacy Ranked.\n\nGlass nerfed, Hanging Chad reworked, Justice banned,\nLet's Go Gambling.",
 			k_badlatro = "Badlatro",

--- a/ui/game/ruleset_info_menu.lua
+++ b/ui/game/ruleset_info_menu.lua
@@ -1,3 +1,33 @@
+-- Render a localized string with {C:colour}...{} tags and \n line breaks as a
+-- stack of UIT rows. loc_parse_string returns nil on empty input, so blank
+-- lines are emitted as spacers without going through it.
+local function parse_colored_lines(str, scale)
+	scale = scale or 0.6
+	local rows = {}
+	for line in (str .. "\n"):gmatch("(.-)\n") do
+		if line == "" then
+			rows[#rows + 1] = { n = G.UIT.R, config = { minh = 0.15 } }
+		else
+			local segments = {}
+			for _, seg in ipairs(loc_parse_string(line)) do
+				local text = seg.strings[1]
+				if type(text) == "string" and text ~= "" then
+					segments[#segments + 1] = {
+						n = G.UIT.T,
+						config = {
+							text = text,
+							scale = scale,
+							colour = loc_colour(seg.control.C, G.C.UI.TEXT_LIGHT),
+						},
+					}
+				end
+			end
+			rows[#rows + 1] = { n = G.UIT.R, config = { align = "cl" }, nodes = segments }
+		end
+	end
+	return rows
+end
+
 function MP.UI.CreateRulesetInfoMenu(config)
 	local has_mp_content = config.multiplayer_content and "k_yes" or "k_no"
 	local has_mp_color = config.multiplayer_content and G.C.GREEN or G.C.RED
@@ -74,12 +104,9 @@ function MP.UI.CreateRulesetInfoMenu(config)
 			},
 			nodes = {
 				{
-					n = G.UIT.T,
-					config = {
-						text = localize(config.description_key),
-						scale = 0.6,
-						colour = G.C.UI.TEXT_LIGHT,
-					},
+					n = G.UIT.C,
+					config = { align = "cl" },
+					nodes = parse_colored_lines(localize(config.description_key), 0.6),
 				},
 			},
 		},


### PR DESCRIPTION
Pipes `description_key` through `loc_parse_string` per line, with an empty-line guard since the parser returns nil on `""`. Experimental description now calls out the 1/3 sticker roll with each sticker name in its badge color — purple, green, red.