### PR TITLE
fix(experimental): multiply ante_scaling instead of overwriting it

### DIFF
--- a/layers/experimental.lua
+++ b/layers/experimental.lua
@@ -35,7 +35,7 @@ MP.Layer("experimental", {
 	},
 	on_apply_bans = function()
 		change_shop_size(1)
-        G.GAME.starting_params.ante_scaling = 1.15
+        G.GAME.starting_params.ante_scaling = (G.GAME.starting_params.ante_scaling or 1) * 1.15
         G.GAME.modifiers.mp_extra_reroll_increment = 1
 
         -- The three modes compose into 2³ = 8 distinct skill expression profiles.


### PR DESCRIPTION
`on_apply_bans` runs after the deck's `apply()`, so setting `starting_params.ante_scaling = 1.15` was silently clobbering Plasma (2) and Echo (1.2). Multiplying preserves the deck contribution: vanilla stays at 1.15, Plasma becomes 2.3, Echo 1.38.

## Test plan
- [x] Plasma deck on Experimental: blind sizes scale ~2.3x per ante
- [x] Echo deck on Experimental: blind sizes scale 1.38x → +0.2 per boss as usual
- [x] Red/any vanilla deck on Experimental: blind sizes scale 1.15x (unchanged)