### PR TITLE
ui(dev-warning): match any version containing 'dev'

### DIFF
--- a/ui/main_menu/dev_warning.lua
+++ b/ui/main_menu/dev_warning.lua
@@ -7,7 +7,7 @@ function MP.UI.show_dev_build_warning()
 	if MP.EXPERIMENTAL.suppress_dev_warning then return end
 
 	local version = SMODS.Mods["Multiplayer"].version or ""
-	if not version:match("~DEV$") then return end
+	if not version:lower():match("dev") then return end
 
 	MP._dev_warning_shown = true
 


### PR DESCRIPTION
## Summary
- The dev-build warning was anchored to `~DEV$`, so newer version strings like `pre1-dev` slipped past it.
- Switched to a case-insensitive substring match on `dev` so any dev-flavored version triggers the popup.

## Test plan
- [ ] Launch with version `pre1-dev` → warning shows
- [ ] Launch with version ending `~DEV` → warning still shows
- [ ] Launch with a clean release version → no warning