### PR TITLE
experimental: pre-check pvp_timer and pressure_timer modifiers

### DIFF
--- a/layers/_layers.lua
+++ b/layers/_layers.lua
@@ -232,6 +232,19 @@ function MP.modifiers_parse(s)
 	end
 end
 
+-- Reset MP.MODIFIERS and seed it from the given ruleset's `default_modifiers`,
+-- if any. Used at ruleset-selection entry points so preset modifiers appear
+-- pre-checked in the overlay while remaining user-editable.
+function MP.apply_default_modifiers(ruleset_short)
+	MP.MODIFIERS = {}
+	if not ruleset_short then return end
+	local ruleset = MP.Rulesets["ruleset_mp_" .. ruleset_short]
+	if not ruleset or not ruleset.default_modifiers then return end
+	for _, name in ipairs(ruleset.default_modifiers) do
+		MP.add_modifier(name)
+	end
+end
+
 -- Fire a named hook on every layer in the active chain. The ruleset's
 -- self-name appears in the chain but isn't registered in MP.Layers, so the
 -- lookup no-ops harmlessly.

--- a/rulesets/experimental/experimental.lua
+++ b/rulesets/experimental/experimental.lua
@@ -1,6 +1,7 @@
 MP.Ruleset({
 	key = "experimental",
 	layers = { "experimental" },
+	default_modifiers = { "pvp_timer", "pressure_timer" },
 	forced_gamemode = "gamemode_mp_attrition",
 	force_lobby_options = function(self)
 		MP.LOBBY.config.the_order = true

--- a/ui/main_menu/play_button/ruleset_selection.lua
+++ b/ui/main_menu/play_button/ruleset_selection.lua
@@ -136,10 +136,11 @@ function G.UIDEF.ruleset_selection_options(mode, buttons)
 	end
 
 	-- Modifiers are per-ruleset; reset on (re)entry to a tab so a previous
-	-- ruleset's toggles can't bleed into the new one.
+	-- ruleset's toggles can't bleed into the new one. Rulesets with
+	-- `default_modifiers` get those pre-checked.
 	-- i'm not a huge fan of any of this living here but
 	-- here we are
-	MP.MODIFIERS = {}
+	MP.apply_default_modifiers(default_ruleset)
 
 	MP.LoadReworks(default_ruleset)
 	MP.UI.ruleset_selection_mode = mode
@@ -176,7 +177,7 @@ function G.FUNCS.change_ruleset_selection(e)
 			else
 				MP.LOBBY.config.ruleset = "ruleset_mp_" .. ruleset_name
 			end
-			MP.MODIFIERS = {}
+			MP.apply_default_modifiers(ruleset_name)
 			MP.LoadReworks(ruleset_name)
 		end
 	)


### PR DESCRIPTION
Adds a `default_modifiers` field on rulesets and seeds `MP.MODIFIERS` from it at ruleset-selection entry. Experimental ships with `{ "pvp_timer", "pressure_timer" }` pre-checked; host can still untick either before creating the lobby.

## Test plan
- [x] Open lobby creation, pick Experimental — PvP timer toggle on, timer cycle set to "pressure"
- [x] Untick PvP timer, switch to another ruleset and back — preset reapplies
- [x] Create lobby with defaults, confirm guest receives both modifiers in serialized form