### PR TITLE
fix(practice): stop previewed rulesets bleeding into ghost replays

### DIFF
--- a/lib/practice_mode.lua
+++ b/lib/practice_mode.lua
@@ -32,18 +32,23 @@ function G.FUNCS.start_practice_run(e)
 		local deck_key = MP.UTILS.get_deck_key_from_name(r.deck)
 		if deck_key then G.GAME.viewed_back = G.P_CENTERS[deck_key] end
 		G.FUNCS.start_run(e, { seed = r.seed, stake = r.stake or 1 })
+		local active_short = (MP.get_active_ruleset() or ""):gsub("^ruleset_mp_", "")
 		sendDebugMessage(
 			string.format(
-				"Practice run state: practice=%s, ghost=%s, ruleset=%s, gamemode=%s, deck_key=%s, lives=%s, enemy_lives=%s, seed=%s, stake=%s",
+				"Practice run state: practice=%s, ghost=%s, ruleset=%s, gamemode=%s, replay_deck=%s, deck_key=%s, viewed_back=%s, lives=%s, enemy_lives=%s, seed=%s, stake=%s, modifiers=[%s], chain=[%s]",
 				tostring(MP.is_practice_mode()),
 				tostring(MP.GHOST.is_active()),
 				tostring(MP.get_active_ruleset()),
 				tostring(MP.get_active_gamemode()),
+				tostring(r.deck),
 				tostring(deck_key),
+				tostring(G.GAME.viewed_back and G.GAME.viewed_back.key or "nil"),
 				tostring(MP.GAME.lives),
 				tostring(MP.GAME.enemy.lives),
 				tostring(G.GAME.pseudorandom and G.GAME.pseudorandom.seed or "?"),
-				tostring(G.GAME.stake or "?")
+				tostring(G.GAME.stake or "?"),
+				table.concat(MP.MODIFIERS, ","),
+				table.concat(MP.active_layer_chain(active_short), ",")
 			),
 			"MULTIPLAYER"
 		)

--- a/ui/game/game_state.lua
+++ b/ui/game/game_state.lua
@@ -352,10 +352,8 @@ end
 
 local start_run_ref = Game.start_run
 function Game:start_run(args)
-	-- MP lobby ruleset if present, else the sp/practice selection. Don't route
-	-- this through get_active_ruleset(): the "sp" run flow leaves practice=false
-	-- yet still sets MP.SP.ruleset, and get_active_ruleset() only honours
-	-- MP.SP.ruleset in practice mode — it'd drop the sp selection to vanilla.
+	-- Not get_active_ruleset(): the sp run flow leaves practice=false but still
+	-- sets MP.SP.ruleset, which get_active_ruleset() only honours in practice.
 	MP.LoadReworks(MP.LOBBY.config.ruleset or MP.SP.ruleset)
 
 	start_run_ref(self, args)

--- a/ui/game/game_state.lua
+++ b/ui/game/game_state.lua
@@ -352,7 +352,10 @@ end
 
 local start_run_ref = Game.start_run
 function Game:start_run(args)
-	-- Use MP ruleset if in lobby, otherwise use SP ruleset (if selected)
+	-- MP lobby ruleset if present, else the sp/practice selection. Don't route
+	-- this through get_active_ruleset(): the "sp" run flow leaves practice=false
+	-- yet still sets MP.SP.ruleset, and get_active_ruleset() only honours
+	-- MP.SP.ruleset in practice mode — it'd drop the sp selection to vanilla.
 	MP.LoadReworks(MP.LOBBY.config.ruleset or MP.SP.ruleset)
 
 	start_run_ref(self, args)

--- a/ui/main_menu/play_button/ghost_replay_picker.lua
+++ b/ui/main_menu/play_button/ghost_replay_picker.lua
@@ -45,9 +45,7 @@ function G.FUNCS.load_previewed_ghost(e)
 	MP.GHOST.load(replay)
 	MP.GHOST.flipped = _preview_flipped
 
-	-- Replay's ruleset wins; if it has none, fall back to whatever the picker
-	-- left in MP.SP.ruleset. If neither exists we're flying blind, but
-	-- apply_default_modifiers(nil) just clears, so we degrade quietly.
+	-- Replay's ruleset, else the picker's current selection.
 	local ruleset_key = replay.ruleset or MP.SP.ruleset
 	if ruleset_key then
 		MP.SP.ruleset = ruleset_key

--- a/ui/main_menu/play_button/ghost_replay_picker.lua
+++ b/ui/main_menu/play_button/ghost_replay_picker.lua
@@ -45,9 +45,14 @@ function G.FUNCS.load_previewed_ghost(e)
 	MP.GHOST.load(replay)
 	MP.GHOST.flipped = _preview_flipped
 
-	if replay.ruleset then
-		MP.SP.ruleset = replay.ruleset
-		local ruleset_name = replay.ruleset:gsub("^ruleset_mp_", "")
+	-- Replay's ruleset wins; if it has none, fall back to whatever the picker
+	-- left in MP.SP.ruleset. If neither exists we're flying blind, but
+	-- apply_default_modifiers(nil) just clears, so we degrade quietly.
+	local ruleset_key = replay.ruleset or MP.SP.ruleset
+	if ruleset_key then
+		MP.SP.ruleset = ruleset_key
+		local ruleset_name = ruleset_key:gsub("^ruleset_mp_", "")
+		MP.apply_default_modifiers(ruleset_name)
 		MP.LoadReworks(ruleset_name)
 	end
 

--- a/ui/main_menu/play_button/play_button_callbacks.lua
+++ b/ui/main_menu/play_button/play_button_callbacks.lua
@@ -37,8 +37,7 @@ end
 function G.FUNCS.create_lobby(e)
 	G.SETTINGS.paused = true
 
-	-- Entering an MP flow: clear any practice/ghost state so a stale practice
-	-- flag can't shadow MP reads during lobby setup (before a code exists).
+	-- Clear practice/ghost state so it can't shadow MP reads during lobby setup.
 	MP.SP.practice = false
 	MP.GHOST.clear()
 	MP.MODIFIERS = {}
@@ -59,8 +58,7 @@ end
 function G.FUNCS.join_lobby(e)
 	G.SETTINGS.paused = true
 
-	-- Same isolation as create_lobby: a guest arriving from practice must not
-	-- carry practice/ghost state into the lobby. Modifiers come from the host.
+	-- Same isolation as create_lobby; modifiers arrive from the host.
 	MP.SP.practice = false
 	MP.GHOST.clear()
 

--- a/ui/main_menu/play_button/play_button_callbacks.lua
+++ b/ui/main_menu/play_button/play_button_callbacks.lua
@@ -37,6 +37,10 @@ end
 function G.FUNCS.create_lobby(e)
 	G.SETTINGS.paused = true
 
+	-- Entering an MP flow: clear any practice/ghost state so a stale practice
+	-- flag can't shadow MP reads during lobby setup (before a code exists).
+	MP.SP.practice = false
+	MP.GHOST.clear()
 	MP.MODIFIERS = {}
 
 	G.FUNCS.overlay_menu({
@@ -54,6 +58,11 @@ end
 
 function G.FUNCS.join_lobby(e)
 	G.SETTINGS.paused = true
+
+	-- Same isolation as create_lobby: a guest arriving from practice must not
+	-- carry practice/ghost state into the lobby. Modifiers come from the host.
+	MP.SP.practice = false
+	MP.GHOST.clear()
 
 	G.FUNCS.overlay_menu({
 		definition = G.UIDEF.create_UIBox_join_lobby_button(),

--- a/ui/main_menu/play_button/ruleset_selection.lua
+++ b/ui/main_menu/play_button/ruleset_selection.lua
@@ -117,11 +117,9 @@ function G.UIDEF.ruleset_selection_tabs(mode)
 	return t
 end
 
--- Single source of truth for "selecting a ruleset writes where?". In sp/practice
--- the selection lives on MP.SP.ruleset; in mp it lives on MP.LOBBY.config.ruleset.
--- Every selection entry point routes through here so the two can't drift — writing
--- the MP global while in practice is exactly what let a previewed ruleset bleed into
--- ghost replays.
+-- sp/practice selections stay local on MP.SP.ruleset; mp writes the shared
+-- MP.LOBBY.config.ruleset. Every writer routes through here so practice can't
+-- touch the MP global.
 local function set_selected_ruleset(mode, ruleset_key)
 	if mode == "sp" or mode == "practice" then
 		MP.SP.ruleset = ruleset_key

--- a/ui/main_menu/play_button/ruleset_selection.lua
+++ b/ui/main_menu/play_button/ruleset_selection.lua
@@ -117,6 +117,19 @@ function G.UIDEF.ruleset_selection_tabs(mode)
 	return t
 end
 
+-- Single source of truth for "selecting a ruleset writes where?". In sp/practice
+-- the selection lives on MP.SP.ruleset; in mp it lives on MP.LOBBY.config.ruleset.
+-- Every selection entry point routes through here so the two can't drift — writing
+-- the MP global while in practice is exactly what let a previewed ruleset bleed into
+-- ghost replays.
+local function set_selected_ruleset(mode, ruleset_key)
+	if mode == "sp" or mode == "practice" then
+		MP.SP.ruleset = ruleset_key
+	else
+		MP.LOBBY.config.ruleset = ruleset_key
+	end
+end
+
 function G.UIDEF.ruleset_selection_options(mode, buttons)
 	mode = mode or "mp"
 	MP.LOBBY.fetched_weekly = "smallworld" -- temp
@@ -129,11 +142,7 @@ function G.UIDEF.ruleset_selection_options(mode, buttons)
 		default_ruleset = string.match(buttons[1].buttons[1].button_id, "(.+)_ruleset_button$")
 	end
 
-	if mode == "sp" or mode == "practice" then
-		MP.SP.ruleset = "ruleset_mp_" .. default_ruleset
-	else
-		MP.LOBBY.config.ruleset = "ruleset_mp_" .. default_ruleset
-	end
+	set_selected_ruleset(mode, "ruleset_mp_" .. default_ruleset)
 
 	-- Modifiers are per-ruleset; reset on (re)entry to a tab so a previous
 	-- ruleset's toggles can't bleed into the new one. Rulesets with
@@ -172,11 +181,7 @@ function G.FUNCS.change_ruleset_selection(e)
 		end,
 		default_button,
 		function(ruleset_name)
-			if mode == "sp" or mode == "practice" then
-				MP.SP.ruleset = "ruleset_mp_" .. ruleset_name
-			else
-				MP.LOBBY.config.ruleset = "ruleset_mp_" .. ruleset_name
-			end
+			set_selected_ruleset(mode, "ruleset_mp_" .. ruleset_name)
 			MP.apply_default_modifiers(ruleset_name)
 			MP.LoadReworks(ruleset_name)
 		end
@@ -271,23 +276,23 @@ function G.FUNCS.ruleset_switch_tabs(args)
 	local active_tab = tabs_wrap.UIBox:get_UIE_by_ID("ruleset_active_tab")
 	local active_tab_idx = active_tab and active_tab.config.tab_idx or 1
 
+	local mode = MP.UI.ruleset_selection_mode or "mp"
 	local tab_type = (args.to_key == 2 and "banned") or (args.to_key == 3 and "rework") or "info"
 	local def = nil
+
+	set_selected_ruleset(mode, callback_args.ruleset.key)
 
 	if tab_type == "banned" then
 		def = G.UIDEF.lobby_setup_tabs_definition(callback_args.ruleset, "banned", active_tab_idx, true)
 		tabs_object.config.tab_type = "banned"
-		MP.LOBBY.config.ruleset = callback_args.ruleset.key
 		MP.LOBBY.ruleset_preview = false
 	elseif tab_type == "rework" then
 		def = G.UIDEF.lobby_setup_tabs_definition(callback_args.ruleset, "rework", active_tab_idx, true)
 		tabs_object.config.tab_type = "rework"
-		MP.LOBBY.config.ruleset = callback_args.ruleset.key
 		MP.LOBBY.ruleset_preview = true
 	else
 		def = G.UIDEF.lobby_setup_tabs_definition(callback_args.ruleset, "info", active_tab_idx, true)
 		tabs_object.config.tab_type = "info"
-		MP.LOBBY.config.ruleset = callback_args.ruleset.key
 		MP.LOBBY.ruleset_preview = false
 	end
 


### PR DESCRIPTION
### Why

Three code paths set "the selected ruleset." Two respected practice mode and wrote `MP.SP.ruleset`. The third — cycling a ruleset's info/bans/reworks tab — wrote `MP.LOBBY.config.ruleset` unconditionally, which shadows `MP.SP.ruleset` everywhere downstream. So previewing Experimental's reworks, then loading a Blitz replay, played Blitz under Experimental's rules and modifiers. The picker was correct by accident, until it wasn't.

### What this does

- Routes all three ruleset-selection writers through one mode-aware helper, so practice/sp selections land on `MP.SP.ruleset` and never touch the MP global.
- Resets and reseeds modifiers from the replay's own ruleset on ghost load (previously left whatever the last-viewed tab seeded).
- Resets `practice`/ghost state at `create_lobby`/`join_lobby`, mirroring the existing guard at `action_start_game`. Practice and MP are now mutually exclusive at every entry point, not just at game start — closes the window where a stale `practice = true` could shadow MP reads during lobby setup.

### What it doesn't do

Reorder `get_active_ruleset`. It stays config-first on purpose: that fails safe toward the lobby config both clients agreed on. Practice-first would risk driving a networked match off local `MP.SP.ruleset`. The Red Deck capture bug is also out of scope — separate change.

### Test plan

- [x] Practice → Experimental tab → view reworks → load a Blitz replay → runs as Blitz (no experimental idol/sticker rolls, no `pressure_timer`).
- [x] Singleplayer run with a non-vanilla ruleset still applies that ruleset's reworks (practice=false path).
- [x] Practice → back → Create/Join Lobby → lobby setup is unaffected by the prior practice session.