### PR TITLE
feat(rulesets): custom ruleset editor — all the knobs, none of the save button

### DIFF
--- a/layers/ban_mutators.lua
+++ b/layers/ban_mutators.lua
@@ -14,13 +14,9 @@ MP.Layer("gambling_opportunity", {
 	},
 })
 
--- No legendary jokers in the pool.
-MP.Layer("no_legendaries", {
+-- No rare jokers in the pool.
+MP.Layer("no_rares", {
 	banned_jokers = {
-		"j_caino",
-		"j_triboulet",
-		"j_yorick",
-		"j_chicot",
-		"j_perkeo",
+		-- todo
 	},
 })

--- a/layers/ban_mutators.lua
+++ b/layers/ban_mutators.lua
@@ -1,0 +1,26 @@
+-- Ban mutator layers (green knobs — pure ban deltas).
+--
+-- These are just `banned_*` arrays. When a layer is active (baked into a ruleset
+-- or picked as a runtime modifier), current_ruleset() unions its ban arrays into
+-- ApplyBans, so no extra wiring is needed.
+
+-- "Gambling Opportunity" (Handsome-Devils): no easy money. Bans the
+-- money-generating enhancements. (Gold-seal / money-edition bans need a card-set
+-- hook, so they're out of the pure-data version — enhancements cover the bulk.)
+MP.Layer("gambling_opportunity", {
+	banned_enhancements = {
+		"m_gold",
+		"m_lucky",
+	},
+})
+
+-- No legendary jokers in the pool.
+MP.Layer("no_legendaries", {
+	banned_jokers = {
+		"j_caino",
+		"j_triboulet",
+		"j_yorick",
+		"j_chicot",
+		"j_perkeo",
+	},
+})

--- a/layers/economy_mutators.lua
+++ b/layers/economy_mutators.lua
@@ -1,0 +1,45 @@
+-- Economy mutator layers (the "big bag" — green knobs).
+--
+-- Pure data. Each declares `game_modifiers` (copied onto G.GAME.modifiers at run
+-- start by the generic applier) and/or `banned_*` arrays (merged via
+-- current_ruleset). No runtime code lives here — these are all engine-native
+-- modifier fields Balatro already reads, so they're deterministic across both
+-- clients (set once at run start).
+--
+-- Contract with the applier: a layer's `game_modifiers = { <id> = value }` is
+-- written to G.GAME.modifiers[<id>]; `starting_params = { <id> = value }` to
+-- G.GAME.starting_params[<id>] (with round_resets propagation handled there).
+
+-- Shop prices climb +$1 per purchase, compounding across the run.
+-- (card.lua: `if G.GAME.modifiers.inflation then G.GAME.inflation = ... + 1`)
+MP.Layer("inflation", {
+	game_modifiers = { inflation = true },
+})
+
+-- No interest paid on held money. Pure economic pressure.
+MP.Layer("no_interest", {
+	game_modifiers = { no_interest = true },
+})
+
+-- Every discard costs $1. (state_events.lua: ease_dollars(-discard_cost) per discard)
+MP.Layer("discard_tax", {
+	game_modifiers = { discard_cost = 1 },
+})
+
+-- Leftover discards pay out at end of round, like unused hands do. A positive
+-- knob to pair against the punishing ones. (default money_per_discard is 0)
+MP.Layer("frugal", {
+	game_modifiers = { money_per_discard = 1 },
+})
+
+-- No cash reward from Small or Big blinds (Boss/PvP payout left intact).
+-- (blind.lua: dollars zeroed when no_blind_reward[blind_type] is set)
+MP.Layer("spartan", {
+	game_modifiers = { no_blind_reward = { Small = true, Big = true } },
+})
+
+-- Booster packs cost +$1 more for each ante you're into the run.
+-- (card.lua set_cost: cost + round_resets.ante - 1 when booster_ante_scaling)
+MP.Layer("pricey_packs", {
+	game_modifiers = { booster_ante_scaling = true },
+})

--- a/layers/esoteric_mutators.lua
+++ b/layers/esoteric_mutators.lua
@@ -1,0 +1,45 @@
+-- Esoteric mutator layers (green knobs — the genuinely weird ones).
+--
+-- All engine-native G.GAME.modifiers flags, so they're pure data and
+-- deterministic. See economy_mutators.lua for the applier contract.
+
+-- Hand is dealt face-down. You play blind. (cardarea.lua / common_events.lua
+-- read modifiers.flipped_cards when drawing.)
+MP.Layer("flipped_cards", {
+	game_modifiers = { flipped_cards = true },
+})
+
+-- Played cards contribute nothing — you win purely on jokers and mult.
+-- (state_events.lua: modifiers.debuff_played_cards)
+MP.Layer("debuff_played_cards", {
+	game_modifiers = { debuff_played_cards = true },
+})
+
+-- Every joker is eternal: can't be sold or destroyed. Your build locks in.
+-- (common_events.lua: modifiers.all_eternal)
+MP.Layer("all_eternal", {
+	game_modifiers = { all_eternal = true },
+})
+
+-- The shop sells jokers carrying eternal / perishable / rental stickers —
+-- roguelike risk on every purchase. (common_events.lua: enable_*_in_shop)
+MP.Layer("sticker_shop", {
+	game_modifiers = {
+		enable_eternals_in_shop = true,
+		enable_perishables_in_shop = true,
+		enable_rentals_in_shop = true,
+	},
+})
+
+-- Scoring chips are capped at your current money. Hoarding cash literally raises
+-- your ceiling. Brutal in PvP — opt-in only. (misc_functions.lua mod_chips:
+-- _chips = min(_chips, max(dollars, 0)))
+MP.Layer("chip_cap", {
+	game_modifiers = { chips_dollar_cap = true },
+})
+
+-- Hand size shrinks by 1 for every $10 you hold. Rich = clumsy.
+-- (cardarea.lua: minus_hand_size_per_X_dollar)
+MP.Layer("shrinking_hand", {
+	game_modifiers = { minus_hand_size_per_X_dollar = 10 },
+})

--- a/layers/glass_cannon.lua
+++ b/layers/glass_cannon.lua
@@ -1,0 +1,32 @@
+-- Glass Cannon (built, not stubbed).
+--
+-- Fragile but devastating: far fewer hands per round, but a flat global multiplier
+-- on every hand's final score. Two halves:
+--   1. data  — `starting_params.hands` (the applier sets this at run start)
+--   2. hook  — a global xmult applied once per hand, gated on the layer
+--
+-- The mult lever is deterministic (no RNG, same hand -> same score) and rides the
+-- existing score sync, so it's MP-safe.
+
+-- Balance knobs (provisional — tune freely).
+local GLASS_CANNON_HANDS = 2
+local GLASS_CANNON_XMULT = 4
+
+MP.Layer("glass_cannon", {
+	starting_params = { hands = GLASS_CANNON_HANDS },
+})
+
+-- final_scoring_step is the canonical once-per-hand seam: vanilla calls it after
+-- all jokers to let the deck rebalance chips/mult (it's where Plasma halves and
+-- recombines). We wrap it, let the real deck run, then scale mult on top when the
+-- layer is live. nu_mult can come back nil (most decks), in which case the engine
+-- falls back to the incoming mult — so we base our scale on (nu_mult or args.mult).
+local _back_trigger_effect = Back.trigger_effect
+function Back:trigger_effect(args)
+	local nu_chip, nu_mult = _back_trigger_effect(self, args)
+	if args and args.context == "final_scoring_step" and MP.is_layer_active("glass_cannon") then
+		local base_mult = nu_mult or args.mult
+		return nu_chip, base_mult * GLASS_CANNON_XMULT
+	end
+	return nu_chip, nu_mult
+end

--- a/layers/mutator_stubs.lua
+++ b/layers/mutator_stubs.lua
@@ -1,0 +1,22 @@
+-- Stubbed mutator layers (yellow knobs — registered but inert).
+--
+-- These need real hooks, not just data. They're registered so they exist in the
+-- layer system and can be composed/selected, but they currently do nothing.
+-- Each note records the intended behavior and the seam it'll hook.
+
+-- PvP REWARD DRAFT ⭐
+-- Beat a PvP blind -> pick 1 of N rewards (joker / tarot / $ / voucher).
+-- Local-only effect (opponent's deck isn't simulated locally), so MP-safe; seed
+-- the offered choices off (lobby seed + ante + player) for reproducible fairness.
+-- Seam: the endPvP / PvP-blind-win path in networking + ui/game.
+MP.Layer("pvp_reward_draft", {})
+
+-- RUBBER-BAND
+-- Losing a life grants an escalating buff (comeback mechanic for casual lobbies).
+-- Seam: the life-loss path (action_set_lives / ease_lives).
+MP.Layer("rubber_band", {})
+
+-- SCORE TAX
+-- Every hand you play nudges your opponent's target up slightly. Pure pressure.
+-- Seam: rides the existing playHand / enemy-score sync.
+MP.Layer("score_tax", {})

--- a/ui/main_menu/play_button/_modifiers_overlay.lua
+++ b/ui/main_menu/play_button/_modifiers_overlay.lua
@@ -1,6 +1,13 @@
 -- Modifier toggles render inline inside the ruleset info panel. The handlers
 -- write MP.MODIFIERS directly (no network) — the host's lobby_options push at
 -- start_lobby carries the serialized list to the guest.
+--
+-- Top section keeps the original descriptive rows (timer cycle + PvP timer, each
+-- with their inline blurb). Below that, the rest of the mutators are a wall of
+-- toggle "pills" grouped into themed columns: dim-tinted when off, full category
+-- colour when on, description on hover. Cells recolour live via a per-frame
+-- `func` (engine reads config.colour each draw) so nothing rebuilds.
+
 local function timer_modifier_to_index()
 	if MP.has_modifier("pressure_timer_plus") then return 4 end
 	if MP.has_modifier("pressure_timer") then return 3 end
@@ -23,8 +30,213 @@ G.FUNCS.change_modifier_timer = function(args)
 	end
 end
 
-G.FUNCS.mp_open_modifiers_overlay = function(e)
-	local timer_cycle = MP.UI.Disableable_Option_Cycle({
+-- One-line blurb per timer option (indices match timer_modifier_to_index).
+-- Shown next to the cycle instead of all four at once; updated live as you cycle.
+local TIMER_BLURBS = {
+	"Regular 150s timer.",
+	"100s timer, animations off.",
+	"100s, no anim, starts at once.",
+	"Pressure, +15s per hand played.",
+}
+
+-- Live-update the timer blurb to match the current cycle selection. Mirrors
+-- display_custom_seed: mutate the child text node and recalculate only on change.
+G.FUNCS.mp_timer_blurb = function(e)
+	local txt = TIMER_BLURBS[timer_modifier_to_index()] or ""
+	if e.children[1] and e.children[1].config.text ~= txt then
+		e.children[1].config.text = txt
+		e.UIBox:recalculate(true)
+	end
+end
+
+-- A compact descriptive row: control on the left, a single text node on the right.
+-- `desc_node` may carry its own `func` (e.g. the timer's live blurb).
+local function compact_entry(option, desc_node)
+	return {
+		n = G.UIT.R,
+		config = {
+			padding = 0.12,
+			align = "cm",
+			r = 0.25,
+			colour = { 1, 1, 1, 0.1 },
+		},
+		nodes = {
+			{
+				n = G.UIT.C,
+				config = { minw = 5, align = "cm" },
+				nodes = { option },
+			},
+			{
+				n = G.UIT.C,
+				config = { align = "cm", maxw = 8.5 },
+				nodes = { desc_node },
+			},
+		},
+	}
+end
+
+-- ---------------------------------------------------------------------------
+-- The wall
+-- ---------------------------------------------------------------------------
+-- View config only — `key` is the layer name (what MP.MODIFIERS stores). Names
+-- and blurbs are inline for now; trivially swappable to localize() later.
+-- Each column shares a colour; cells tint dark when off, bright when on.
+local MUTATOR_WALL = {
+	{
+		name = "ECONOMY",
+		colour = G.C.MONEY,
+		cells = {
+			{ key = "inflation", label = "Inflation", desc = { "Shop prices creep up $1 with", "every card you buy." } },
+			{ key = "no_interest", label = "No Interest", desc = { "Savings earn nothing.", "Spend it or lose the edge." } },
+			{ key = "discard_tax", label = "Discard Tax", desc = { "Every discard costs $1.", "Think before you toss." } },
+			{ key = "frugal", label = "Frugal", desc = { "Unspent discards pay out,", "like leftover hands do." } },
+		},
+	},
+	{
+		name = "MAYHEM",
+		colour = G.C.PURPLE,
+		cells = {
+			{ key = "flipped_cards", label = "Blind Poker", desc = { "Your hand is dealt face-down.", "Play by memory and nerve." } },
+			{ key = "debuff_played_cards", label = "Dead Cards", desc = { "Played cards score zero.", "Jokers are the whole engine." } },
+			{ key = "all_eternal", label = "No Takebacks", desc = { "Every joker is eternal —", "unsellable, undestroyable." } },
+			{ key = "shrinking_hand", label = "Heavy Pockets", desc = { "-1 hand size for every $10", "you're holding. Rich, clumsy." } },
+		},
+	},
+	{
+		name = "HAZARDS",
+		colour = G.C.RED,
+		cells = {
+			{ key = "gambling_opportunity", label = "No Easy Money", desc = { "No Gold or Lucky cards.", "Earn it the hard way." } },
+			{ key = "no_legendaries", label = "No Legends", desc = { "The five legendary jokers", "are out of the pool." } },
+			{ key = "sticker_shop", label = "Risky Shelf", desc = { "Shop stocks eternal, perishable", "and rental jokers. Beware." } },
+			{ key = "chip_cap", label = "Cash Ceiling", desc = { "Chip score can't exceed your", "cash. Greed is the only way up." } },
+		},
+	},
+	{
+		name = "CHAOS",
+		colour = G.C.ORANGE,
+		cells = {
+			{ key = "glass_cannon", label = "Glass Cannon", desc = { "Only 2 hands a round — but", "every hand hits for 4x mult." } },
+			{ key = "smallworld", label = "Small World", desc = { "75% of the pool banned at", "random. Showman always on." } },
+			{ key = "spartan", label = "Spartan", desc = { "No cash from Small or Big", "blinds. Lean times." } },
+			{ key = "pricey_packs", label = "Pricey Packs", desc = { "Booster packs cost more", "for each ante you reach." } },
+		},
+	},
+}
+
+local SOON = {
+	colour = G.C.GREY,
+	cells = {
+		{ key = "pvp_reward_draft", label = "Reward Draft", desc = { "Win a PvP blind, draft 1 of 3", "rewards.", "(coming soon)" } },
+		{ key = "rubber_band", label = "Rubber Band", desc = { "Falling behind grants", "escalating buffs.", "(coming soon)" } },
+		{ key = "score_tax", label = "Score Tax", desc = { "Each hand you play raises", "your opponent's target.", "(coming soon)" } },
+	},
+}
+
+G.FUNCS.mp_toggle_mutator = function(e)
+	local key = e.config.ref_table.key
+	MP.MUTATORS_BLIND = false -- touching anything reveals the wall
+	if MP.has_modifier(key) then
+		MP.remove_modifier(key)
+		play_sound("cardSlide2", 1.1, 0.4)
+	else
+		MP.add_modifier(key)
+		play_sound("cardSlide1", 1.1, 0.5)
+	end
+	e:juice_up(0.2, 0.1)
+end
+
+-- Live recolour: bright when the modifier is active, dim-tinted otherwise.
+-- In blind mode the wall lies — active cells read as off, so you go in blind.
+G.FUNCS.mp_mutator_cell_colour = function(e)
+	local rt = e.config.ref_table
+	local lit = MP.has_modifier(rt.key) and not MP.MUTATORS_BLIND
+	e.config.colour = lit and rt.on or rt.off
+end
+
+-- Roll a fresh random loadout across the whole wall (~1 in 3 odds per knob).
+local function roll_mutators()
+	for _, cat in ipairs(MUTATOR_WALL) do
+		for _, cell in ipairs(cat.cells) do
+			MP.remove_modifier(cell.key)
+			if math.random() < 0.35 then MP.add_modifier(cell.key) end
+		end
+	end
+end
+
+G.FUNCS.mp_randomize_mutators = function(e)
+	MP.MUTATORS_BLIND = false
+	roll_mutators()
+	play_sound("generic1", 1.0, 0.5)
+	e:juice_up(0.3, 0.1)
+end
+
+G.FUNCS.mp_blind_random_mutators = function(e)
+	roll_mutators()
+	MP.MUTATORS_BLIND = true -- keep the roll a secret
+	play_sound("timpani", 1.0, 0.5)
+	e:juice_up(0.3, 0.1)
+end
+
+local function mutator_cell(cell, colour, disabled)
+	local on = colour
+	local off = darken(colour, 0.72)
+	return {
+		n = G.UIT.R,
+		config = { align = "cm", padding = 0.035 },
+		nodes = {
+			{
+				n = G.UIT.C,
+				config = {
+					align = "cm",
+					minw = 2.5,
+					minh = 0.46,
+					padding = 0.06,
+					r = 0.1,
+					emboss = 0.05,
+					hover = true,
+					shadow = not disabled,
+					colour = disabled and G.C.UI.BACKGROUND_INACTIVE or off,
+					button = not disabled and "mp_toggle_mutator" or nil,
+					func = not disabled and "mp_mutator_cell_colour" or nil,
+					ref_table = { key = cell.key, on = on, off = off },
+					tooltip = { title = cell.label, text = cell.desc },
+				},
+				nodes = {
+					{
+						n = G.UIT.T,
+						config = {
+							text = cell.label,
+							scale = 0.34,
+							colour = disabled and G.C.UI.TEXT_INACTIVE or G.C.UI.TEXT_LIGHT,
+						},
+					},
+				},
+			},
+		},
+	}
+end
+
+local function mutator_column(cat)
+	local nodes = {
+		{
+			n = G.UIT.R,
+			config = { align = "cm", padding = 0.04, minh = 0.4 },
+			nodes = { { n = G.UIT.T, config = { text = cat.name, scale = 0.4, colour = cat.colour, shadow = true } } },
+		},
+	}
+	for _, cell in ipairs(cat.cells) do
+		nodes[#nodes + 1] = mutator_cell(cell, cat.colour)
+	end
+	return { n = G.UIT.C, config = { align = "tm", padding = 0.06 }, nodes = nodes }
+end
+
+-- ---------------------------------------------------------------------------
+-- Reusable builders (shared by the standalone overlay and the inline custom-
+-- ruleset editor — one source of truth for the wall + timer controls).
+-- ---------------------------------------------------------------------------
+function MP.UI.build_timer_modifier_cycle()
+	return MP.UI.Disableable_Option_Cycle({
 		id = "modifier_timer_option",
 		enabled_ref_table = { val = true },
 		enabled_ref_value = "val",
@@ -36,22 +248,10 @@ G.FUNCS.mp_open_modifiers_overlay = function(e)
 		minw = 4,
 		w = 4,
 	})
+end
 
-	local smallworld_toggle = create_toggle({
-		id = "modifier_smallworld_toggle",
-		label = localize("b_opts_modifier_smallworld"),
-		ref_table = { val = MP.has_modifier("smallworld") },
-		ref_value = "val",
-		callback = function(new_val)
-			if new_val then
-				MP.add_modifier("smallworld")
-			else
-				MP.remove_modifier("smallworld")
-			end
-		end,
-	})
-
-	local pvp_timer_toggle = create_toggle({
+function MP.UI.build_pvp_timer_toggle()
+	return create_toggle({
 		id = "modifier_pvp_timer_toggle",
 		label = localize("b_opts_modifier_pvp_timer"),
 		ref_table = { val = MP.has_modifier("pvp_timer") },
@@ -64,44 +264,113 @@ G.FUNCS.mp_open_modifiers_overlay = function(e)
 			end
 		end,
 	})
+end
 
-	local function create_entry(option, loc_key)
-		local message_table = localize(loc_key)
-		local result_text = {}
-		for _, line in ipairs(message_table) do
-			table.insert(result_text, {
-				n = G.UIT.R,
-				config = { minw = 8.5, maxw = 8.5 },
-				nodes = SMODS.localize_box(loc_parse_string(line), {
-					default_col = G.C.UI.TEXT_LIGHT,
-				}),
-			})
-		end
-
-		return {
-			n = G.UIT.R,
-			config = {
-				padding = 0.25,
-				align = "cm",
-				r = 0.25,
-				colour = { 1, 1, 1, 0.1 },
-			},
-			nodes = {
-				{
-					n = G.UIT.C,
-					config = { minw = 5, align = "cm" },
-					nodes = {
-						option,
-					},
-				},
-				{
-					n = G.UIT.C,
-					config = { align = "cm" },
-					nodes = result_text,
-				},
-			},
-		}
+-- The MUTATORS wall block: header + subtitle + themed columns + coming-soon line.
+-- Returns one node (rows stack vertically since they're R children).
+function MP.UI.build_mutators_wall()
+	local columns = {}
+	for _, cat in ipairs(MUTATOR_WALL) do
+		columns[#columns + 1] = mutator_column(cat)
 	end
+	local soon_labels = {}
+	for _, cell in ipairs(SOON.cells) do
+		soon_labels[#soon_labels + 1] = cell.label
+	end
+	local soon_line = "coming soon · " .. table.concat(soon_labels, " · ")
+	return {
+		n = G.UIT.R,
+		config = { align = "cm" },
+		nodes = {
+			{
+				n = G.UIT.R,
+				config = { align = "cm", padding = 0.02 },
+				nodes = { { n = G.UIT.T, config = { text = "MUTATORS", scale = 0.5, colour = G.C.UI.TEXT_LIGHT, shadow = true } } },
+			},
+			{
+				n = G.UIT.R,
+				config = { align = "cm", padding = 0.02 },
+				nodes = { { n = G.UIT.T, config = { text = "stack freely · hover for details", scale = 0.3, colour = G.C.UI.TEXT_INACTIVE } } },
+			},
+			{ n = G.UIT.R, config = { align = "cm", padding = 0.04 }, nodes = columns },
+			{ n = G.UIT.R, config = { minh = 0.06 } },
+			{
+				n = G.UIT.R,
+				config = { align = "cm", padding = 0.02 },
+				nodes = { { n = G.UIT.T, config = { text = soon_line, scale = 0.3, colour = G.C.UI.TEXT_INACTIVE } } },
+			},
+		},
+	}
+end
+
+-- Randomize / Blind Random pair (operate on MP.MODIFIERS via the global FUNCS).
+function MP.UI.build_mutator_randomize_row()
+	return {
+		n = G.UIT.R,
+		config = { align = "cm", padding = 0.05 },
+		nodes = {
+			{
+				n = G.UIT.C,
+				config = { align = "cm", padding = 0.05 },
+				nodes = {
+					UIBox_button({
+						id = "mp_randomize_mutators_btn",
+						button = "mp_randomize_mutators",
+						label = { "Randomize" },
+						colour = G.C.ORANGE,
+						minw = 2.8,
+						minh = 0.7,
+						scale = 0.4,
+						hover = true,
+						shadow = true,
+					}),
+				},
+			},
+			{
+				n = G.UIT.C,
+				config = { align = "cm", padding = 0.05 },
+				nodes = {
+					UIBox_button({
+						id = "mp_blind_random_mutators_btn",
+						button = "mp_blind_random_mutators",
+						label = { "Blind Random" },
+						colour = G.C.PURPLE,
+						minw = 2.8,
+						minh = 0.7,
+						scale = 0.4,
+						hover = true,
+						shadow = true,
+					}),
+				},
+			},
+		},
+	}
+end
+
+G.FUNCS.mp_open_modifiers_overlay = function(e)
+	local timer_cycle = MP.UI.build_timer_modifier_cycle()
+	local pvp_timer_toggle = MP.UI.build_pvp_timer_toggle()
+
+	-- timer blurb: a single line that re-reads the current selection each frame
+	local timer_blurb = {
+		n = G.UIT.R,
+		config = { align = "cm", func = "mp_timer_blurb" },
+		nodes = {
+			{
+				n = G.UIT.T,
+				config = {
+					text = TIMER_BLURBS[timer_modifier_to_index()],
+					scale = 0.34,
+					colour = G.C.UI.TEXT_LIGHT,
+				},
+			},
+		},
+	}
+
+	local pvp_blurb = {
+		n = G.UIT.T,
+		config = { text = "Live timer during PvP blinds.", scale = 0.34, colour = G.C.UI.TEXT_LIGHT },
+	}
 
 	local back_func = MP.is_practice_mode() and "mp_open_practice_options_overlay" or "create_lobby"
 
@@ -111,24 +380,62 @@ G.FUNCS.mp_open_modifiers_overlay = function(e)
 			contents = {
 				{
 					n = G.UIT.R,
-					config = { align = "cm", padding = 0.25, colour = G.C.BLACK, r = 0.25 },
+					config = { align = "cm", padding = 0.18, colour = G.C.BLACK, r = 0.25 },
 					nodes = {
+						-- compact descriptive rows (timer blurb updates as you cycle)
+						compact_entry(timer_cycle, timer_blurb),
+						{ n = G.UIT.R, config = { minh = 0.08 } },
+						compact_entry(pvp_timer_toggle, pvp_blurb),
+						{ n = G.UIT.R, config = { minh = 0.12 } },
+						-- shared mutators wall (header + subtitle + columns + coming-soon)
+						MP.UI.build_mutators_wall(),
+						{ n = G.UIT.R, config = { minh = 0.1 } },
+						-- randomize · blind · play
 						{
 							n = G.UIT.R,
+							config = { align = "cm", padding = 0.05 },
 							nodes = {
-								create_entry(timer_cycle, "k_experimental_modifiers_timers"),
-								{ n = G.UIT.R, config = { minh = 0.25 } },
-								create_entry(pvp_timer_toggle, "k_experimental_modifiers_pvp_timer"),
-								{ n = G.UIT.R, config = { minh = 0.25 } },
-								create_entry(smallworld_toggle, "k_experimental_modifiers_smallworld"),
-							},
-						},
-						{ n = G.UIT.R },
-						{
-							n = G.UIT.R,
-							config = { align = "cm" },
-							nodes = {
-								MP.UI.get_continue_button(e.config.ref_table.ruleset, e.config.ref_table.mode),
+								{
+									n = G.UIT.C,
+									config = { align = "cm", padding = 0.05 },
+									nodes = {
+										UIBox_button({
+											id = "mp_randomize_mutators_btn",
+											button = "mp_randomize_mutators",
+											label = { "Randomize" },
+											colour = G.C.ORANGE,
+											minw = 2.8,
+											minh = 0.8,
+											scale = 0.42,
+											hover = true,
+											shadow = true,
+										}),
+									},
+								},
+								{
+									n = G.UIT.C,
+									config = { align = "cm", padding = 0.05 },
+									nodes = {
+										UIBox_button({
+											id = "mp_blind_random_mutators_btn",
+											button = "mp_blind_random_mutators",
+											label = { "Blind Random" },
+											colour = G.C.PURPLE,
+											minw = 2.8,
+											minh = 0.8,
+											scale = 0.42,
+											hover = true,
+											shadow = true,
+										}),
+									},
+								},
+								{
+									n = G.UIT.C,
+									config = { align = "cm", padding = 0.05 },
+									nodes = {
+										MP.UI.get_continue_button(e.config.ref_table.ruleset, e.config.ref_table.mode),
+									},
+								},
 							},
 						},
 					},

--- a/ui/main_menu/play_button/_modifiers_overlay.lua
+++ b/ui/main_menu/play_button/_modifiers_overlay.lua
@@ -1,376 +1,58 @@
--- Modifier toggles render inline inside the ruleset info panel. The handlers
--- write MP.MODIFIERS directly (no network) — the host's lobby_options push at
--- start_lobby carries the serialized list to the guest.
---
--- Top section keeps the original descriptive rows (timer cycle + PvP timer, each
--- with their inline blurb). Below that, the rest of the mutators are a wall of
--- toggle "pills" grouped into themed columns: dim-tinted when off, full category
--- colour when on, description on hover. Cells recolour live via a per-frame
--- `func` (engine reads config.colour each draw) so nothing rebuilds.
-
-local function timer_modifier_to_index()
-	if MP.has_modifier("pressure_timer_plus") then return 4 end
-	if MP.has_modifier("pressure_timer") then return 3 end
-	if MP.has_modifier("no_animation_timer") then return 2 end
-	return 1
-end
-
--- Indices line up with localization ml_mp_modifier_timer_opt: 1=default, 2=no_anim, 3=pressure
-G.FUNCS.change_modifier_timer = function(args)
-	MP.remove_modifier("no_animation_timer")
-	MP.remove_modifier("pressure_timer")
-	MP.remove_modifier("pressure_timer_plus")
-	if args.to_key == 2 then
-		MP.add_modifier("no_animation_timer")
-	elseif args.to_key == 3 then
-		MP.add_modifier("pressure_timer")
-	elseif args.to_key == 4 then
-		MP.add_modifier("pressure_timer")
-		MP.add_modifier("pressure_timer_plus")
-	end
-end
-
--- One-line blurb per timer option (indices match timer_modifier_to_index).
--- Shown next to the cycle instead of all four at once; updated live as you cycle.
-local TIMER_BLURBS = {
-	"Regular 150s timer.",
-	"100s timer, animations off.",
-	"100s, no anim, starts at once.",
-	"Pressure, +15s per hand played.",
-}
-
--- Live-update the timer blurb to match the current cycle selection. Mirrors
--- display_custom_seed: mutate the child text node and recalculate only on change.
-G.FUNCS.mp_timer_blurb = function(e)
-	local txt = TIMER_BLURBS[timer_modifier_to_index()] or ""
-	if e.children[1] and e.children[1].config.text ~= txt then
-		e.children[1].config.text = txt
-		e.UIBox:recalculate(true)
-	end
-end
-
--- A compact descriptive row: control on the left, a single text node on the right.
--- `desc_node` may carry its own `func` (e.g. the timer's live blurb).
-local function compact_entry(option, desc_node)
-	return {
-		n = G.UIT.R,
-		config = {
-			padding = 0.12,
-			align = "cm",
-			r = 0.25,
-			colour = { 1, 1, 1, 0.1 },
-		},
-		nodes = {
-			{
-				n = G.UIT.C,
-				config = { minw = 5, align = "cm" },
-				nodes = { option },
-			},
-			{
-				n = G.UIT.C,
-				config = { align = "cm", maxw = 8.5 },
-				nodes = { desc_node },
-			},
-		},
-	}
-end
-
--- ---------------------------------------------------------------------------
--- The wall
--- ---------------------------------------------------------------------------
--- View config only — `key` is the layer name (what MP.MODIFIERS stores). Names
--- and blurbs are inline for now; trivially swappable to localize() later.
--- Each column shares a colour; cells tint dark when off, bright when on.
-local MUTATOR_WALL = {
-	{
-		name = "ECONOMY",
-		colour = G.C.MONEY,
-		cells = {
-			{ key = "inflation", label = "Inflation", desc = { "Shop prices creep up $1 with", "every card you buy." } },
-			{ key = "no_interest", label = "No Interest", desc = { "Savings earn nothing.", "Spend it or lose the edge." } },
-			{ key = "discard_tax", label = "Discard Tax", desc = { "Every discard costs $1.", "Think before you toss." } },
-			{ key = "frugal", label = "Frugal", desc = { "Unspent discards pay out,", "like leftover hands do." } },
-		},
-	},
-	{
-		name = "MAYHEM",
-		colour = G.C.PURPLE,
-		cells = {
-			{ key = "flipped_cards", label = "Blind Poker", desc = { "Your hand is dealt face-down.", "Play by memory and nerve." } },
-			{ key = "debuff_played_cards", label = "Dead Cards", desc = { "Played cards score zero.", "Jokers are the whole engine." } },
-			{ key = "all_eternal", label = "No Takebacks", desc = { "Every joker is eternal —", "unsellable, undestroyable." } },
-			{ key = "shrinking_hand", label = "Heavy Pockets", desc = { "-1 hand size for every $10", "you're holding. Rich, clumsy." } },
-		},
-	},
-	{
-		name = "HAZARDS",
-		colour = G.C.RED,
-		cells = {
-			{ key = "gambling_opportunity", label = "No Easy Money", desc = { "No Gold or Lucky cards.", "Earn it the hard way." } },
-			{ key = "no_legendaries", label = "No Legends", desc = { "The five legendary jokers", "are out of the pool." } },
-			{ key = "sticker_shop", label = "Risky Shelf", desc = { "Shop stocks eternal, perishable", "and rental jokers. Beware." } },
-			{ key = "chip_cap", label = "Cash Ceiling", desc = { "Chip score can't exceed your", "cash. Greed is the only way up." } },
-		},
-	},
-	{
-		name = "CHAOS",
-		colour = G.C.ORANGE,
-		cells = {
-			{ key = "glass_cannon", label = "Glass Cannon", desc = { "Only 2 hands a round — but", "every hand hits for 4x mult." } },
-			{ key = "smallworld", label = "Small World", desc = { "75% of the pool banned at", "random. Showman always on." } },
-			{ key = "spartan", label = "Spartan", desc = { "No cash from Small or Big", "blinds. Lean times." } },
-			{ key = "pricey_packs", label = "Pricey Packs", desc = { "Booster packs cost more", "for each ante you reach." } },
-		},
-	},
-}
-
-local SOON = {
-	colour = G.C.GREY,
-	cells = {
-		{ key = "pvp_reward_draft", label = "Reward Draft", desc = { "Win a PvP blind, draft 1 of 3", "rewards.", "(coming soon)" } },
-		{ key = "rubber_band", label = "Rubber Band", desc = { "Falling behind grants", "escalating buffs.", "(coming soon)" } },
-		{ key = "score_tax", label = "Score Tax", desc = { "Each hand you play raises", "your opponent's target.", "(coming soon)" } },
-	},
-}
-
-G.FUNCS.mp_toggle_mutator = function(e)
-	local key = e.config.ref_table.key
-	MP.MUTATORS_BLIND = false -- touching anything reveals the wall
-	if MP.has_modifier(key) then
-		MP.remove_modifier(key)
-		play_sound("cardSlide2", 1.1, 0.4)
-	else
-		MP.add_modifier(key)
-		play_sound("cardSlide1", 1.1, 0.5)
-	end
-	e:juice_up(0.2, 0.1)
-end
-
--- Live recolour: bright when the modifier is active, dim-tinted otherwise.
--- In blind mode the wall lies — active cells read as off, so you go in blind.
-G.FUNCS.mp_mutator_cell_colour = function(e)
-	local rt = e.config.ref_table
-	local lit = MP.has_modifier(rt.key) and not MP.MUTATORS_BLIND
-	e.config.colour = lit and rt.on or rt.off
-end
-
--- Roll a fresh random loadout across the whole wall (~1 in 3 odds per knob).
-local function roll_mutators()
-	for _, cat in ipairs(MUTATOR_WALL) do
-		for _, cell in ipairs(cat.cells) do
-			MP.remove_modifier(cell.key)
-			if math.random() < 0.35 then MP.add_modifier(cell.key) end
-		end
-	end
-end
-
-G.FUNCS.mp_randomize_mutators = function(e)
-	MP.MUTATORS_BLIND = false
-	roll_mutators()
-	play_sound("generic1", 1.0, 0.5)
-	e:juice_up(0.3, 0.1)
-end
-
-G.FUNCS.mp_blind_random_mutators = function(e)
-	roll_mutators()
-	MP.MUTATORS_BLIND = true -- keep the roll a secret
-	play_sound("timpani", 1.0, 0.5)
-	e:juice_up(0.3, 0.1)
-end
-
-local function mutator_cell(cell, colour, disabled)
-	local on = colour
-	local off = darken(colour, 0.72)
-	return {
-		n = G.UIT.R,
-		config = { align = "cm", padding = 0.035 },
-		nodes = {
-			{
-				n = G.UIT.C,
-				config = {
-					align = "cm",
-					minw = 2.5,
-					minh = 0.46,
-					padding = 0.06,
-					r = 0.1,
-					emboss = 0.05,
-					hover = true,
-					shadow = not disabled,
-					colour = disabled and G.C.UI.BACKGROUND_INACTIVE or off,
-					button = not disabled and "mp_toggle_mutator" or nil,
-					func = not disabled and "mp_mutator_cell_colour" or nil,
-					ref_table = { key = cell.key, on = on, off = off },
-					tooltip = { title = cell.label, text = cell.desc },
-				},
-				nodes = {
-					{
-						n = G.UIT.T,
-						config = {
-							text = cell.label,
-							scale = 0.34,
-							colour = disabled and G.C.UI.TEXT_INACTIVE or G.C.UI.TEXT_LIGHT,
-						},
-					},
-				},
-			},
-		},
-	}
-end
-
-local function mutator_column(cat)
-	local nodes = {
-		{
-			n = G.UIT.R,
-			config = { align = "cm", padding = 0.04, minh = 0.4 },
-			nodes = { { n = G.UIT.T, config = { text = cat.name, scale = 0.4, colour = cat.colour, shadow = true } } },
-		},
-	}
-	for _, cell in ipairs(cat.cells) do
-		nodes[#nodes + 1] = mutator_cell(cell, cat.colour)
-	end
-	return { n = G.UIT.C, config = { align = "tm", padding = 0.06 }, nodes = nodes }
-end
-
--- ---------------------------------------------------------------------------
--- Reusable builders (shared by the standalone overlay and the inline custom-
--- ruleset editor — one source of truth for the wall + timer controls).
--- ---------------------------------------------------------------------------
-function MP.UI.build_timer_modifier_cycle()
-	return MP.UI.Disableable_Option_Cycle({
-		id = "modifier_timer_option",
-		enabled_ref_table = { val = true },
-		enabled_ref_value = "val",
-		label = localize("k_opts_modifier_timer"),
-		scale = 0.8,
-		options = localize("ml_mp_modifier_timer_opt"),
-		current_option = timer_modifier_to_index(),
-		opt_callback = "change_modifier_timer",
-		minw = 4,
-		w = 4,
-	})
-end
-
-function MP.UI.build_pvp_timer_toggle()
-	return create_toggle({
-		id = "modifier_pvp_timer_toggle",
-		label = localize("b_opts_modifier_pvp_timer"),
-		ref_table = { val = MP.has_modifier("pvp_timer") },
-		ref_value = "val",
-		callback = function(new_val)
-			if new_val then
-				MP.add_modifier("pvp_timer")
-			else
-				MP.remove_modifier("pvp_timer")
-			end
-		end,
-	})
-end
-
--- The MUTATORS wall block: header + subtitle + themed columns + coming-soon line.
--- Returns one node (rows stack vertically since they're R children).
-function MP.UI.build_mutators_wall()
-	local columns = {}
-	for _, cat in ipairs(MUTATOR_WALL) do
-		columns[#columns + 1] = mutator_column(cat)
-	end
-	local soon_labels = {}
-	for _, cell in ipairs(SOON.cells) do
-		soon_labels[#soon_labels + 1] = cell.label
-	end
-	local soon_line = "coming soon · " .. table.concat(soon_labels, " · ")
-	return {
-		n = G.UIT.R,
-		config = { align = "cm" },
-		nodes = {
-			{
-				n = G.UIT.R,
-				config = { align = "cm", padding = 0.02 },
-				nodes = { { n = G.UIT.T, config = { text = "MUTATORS", scale = 0.5, colour = G.C.UI.TEXT_LIGHT, shadow = true } } },
-			},
-			{
-				n = G.UIT.R,
-				config = { align = "cm", padding = 0.02 },
-				nodes = { { n = G.UIT.T, config = { text = "stack freely · hover for details", scale = 0.3, colour = G.C.UI.TEXT_INACTIVE } } },
-			},
-			{ n = G.UIT.R, config = { align = "cm", padding = 0.04 }, nodes = columns },
-			{ n = G.UIT.R, config = { minh = 0.06 } },
-			{
-				n = G.UIT.R,
-				config = { align = "cm", padding = 0.02 },
-				nodes = { { n = G.UIT.T, config = { text = soon_line, scale = 0.3, colour = G.C.UI.TEXT_INACTIVE } } },
-			},
-		},
-	}
-end
-
--- Randomize / Blind Random pair (operate on MP.MODIFIERS via the global FUNCS).
-function MP.UI.build_mutator_randomize_row()
-	return {
-		n = G.UIT.R,
-		config = { align = "cm", padding = 0.05 },
-		nodes = {
-			{
-				n = G.UIT.C,
-				config = { align = "cm", padding = 0.05 },
-				nodes = {
-					UIBox_button({
-						id = "mp_randomize_mutators_btn",
-						button = "mp_randomize_mutators",
-						label = { "Randomize" },
-						colour = G.C.ORANGE,
-						minw = 2.8,
-						minh = 0.7,
-						scale = 0.4,
-						hover = true,
-						shadow = true,
-					}),
-				},
-			},
-			{
-				n = G.UIT.C,
-				config = { align = "cm", padding = 0.05 },
-				nodes = {
-					UIBox_button({
-						id = "mp_blind_random_mutators_btn",
-						button = "mp_blind_random_mutators",
-						label = { "Blind Random" },
-						colour = G.C.PURPLE,
-						minw = 2.8,
-						minh = 0.7,
-						scale = 0.4,
-						hover = true,
-						shadow = true,
-					}),
-				},
-			},
-		},
-	}
-end
-
 G.FUNCS.mp_open_modifiers_overlay = function(e)
 	local timer_cycle = MP.UI.build_timer_modifier_cycle()
 	local pvp_timer_toggle = MP.UI.build_pvp_timer_toggle()
 
-	-- timer blurb: a single line that re-reads the current selection each frame
-	local timer_blurb = {
-		n = G.UIT.R,
-		config = { align = "cm", func = "mp_timer_blurb" },
-		nodes = {
-			{
-				n = G.UIT.T,
-				config = {
-					text = TIMER_BLURBS[timer_modifier_to_index()],
-					scale = 0.34,
-					colour = G.C.UI.TEXT_LIGHT,
+	local smallworld_toggle = create_toggle({
+		id = "modifier_smallworld_toggle",
+		label = localize("b_opts_modifier_smallworld"),
+		ref_table = { val = MP.has_modifier("smallworld") },
+		ref_value = "val",
+		callback = function(new_val)
+			if new_val then
+				MP.add_modifier("smallworld")
+			else
+				MP.remove_modifier("smallworld")
+			end
+		end,
+	})
+
+	local function create_entry(option, loc_key)
+		local message_table = localize(loc_key)
+		local result_text = {}
+		for _, line in ipairs(message_table) do
+			table.insert(result_text, {
+				n = G.UIT.R,
+				config = { minw = 8.5, maxw = 8.5 },
+				nodes = SMODS.localize_box(loc_parse_string(line), {
+					default_col = G.C.UI.TEXT_LIGHT,
+				}),
+			})
+		end
+
+		return {
+			n = G.UIT.R,
+			config = {
+				padding = 0.25,
+				align = "cm",
+				r = 0.25,
+				colour = { 1, 1, 1, 0.1 },
+			},
+			nodes = {
+				{
+					n = G.UIT.C,
+					config = { minw = 5, align = "cm" },
+					nodes = {
+						option,
+					},
+				},
+				{
+					n = G.UIT.C,
+					config = { align = "cm" },
+					nodes = result_text,
 				},
 			},
-		},
-	}
-
-	local pvp_blurb = {
-		n = G.UIT.T,
-		config = { text = "Live timer during PvP blinds.", scale = 0.34, colour = G.C.UI.TEXT_LIGHT },
-	}
+		}
+	end
 
 	local back_func = MP.is_practice_mode() and "mp_open_practice_options_overlay" or "create_lobby"
 
@@ -380,62 +62,24 @@ G.FUNCS.mp_open_modifiers_overlay = function(e)
 			contents = {
 				{
 					n = G.UIT.R,
-					config = { align = "cm", padding = 0.18, colour = G.C.BLACK, r = 0.25 },
+					config = { align = "cm", padding = 0.25, colour = G.C.BLACK, r = 0.25 },
 					nodes = {
-						-- compact descriptive rows (timer blurb updates as you cycle)
-						compact_entry(timer_cycle, timer_blurb),
-						{ n = G.UIT.R, config = { minh = 0.08 } },
-						compact_entry(pvp_timer_toggle, pvp_blurb),
-						{ n = G.UIT.R, config = { minh = 0.12 } },
-						-- shared mutators wall (header + subtitle + columns + coming-soon)
-						MP.UI.build_mutators_wall(),
-						{ n = G.UIT.R, config = { minh = 0.1 } },
-						-- randomize · blind · play
 						{
 							n = G.UIT.R,
-							config = { align = "cm", padding = 0.05 },
 							nodes = {
-								{
-									n = G.UIT.C,
-									config = { align = "cm", padding = 0.05 },
-									nodes = {
-										UIBox_button({
-											id = "mp_randomize_mutators_btn",
-											button = "mp_randomize_mutators",
-											label = { "Randomize" },
-											colour = G.C.ORANGE,
-											minw = 2.8,
-											minh = 0.8,
-											scale = 0.42,
-											hover = true,
-											shadow = true,
-										}),
-									},
-								},
-								{
-									n = G.UIT.C,
-									config = { align = "cm", padding = 0.05 },
-									nodes = {
-										UIBox_button({
-											id = "mp_blind_random_mutators_btn",
-											button = "mp_blind_random_mutators",
-											label = { "Blind Random" },
-											colour = G.C.PURPLE,
-											minw = 2.8,
-											minh = 0.8,
-											scale = 0.42,
-											hover = true,
-											shadow = true,
-										}),
-									},
-								},
-								{
-									n = G.UIT.C,
-									config = { align = "cm", padding = 0.05 },
-									nodes = {
-										MP.UI.get_continue_button(e.config.ref_table.ruleset, e.config.ref_table.mode),
-									},
-								},
+								create_entry(timer_cycle, "k_experimental_modifiers_timers"),
+								{ n = G.UIT.R, config = { minh = 0.25 } },
+								create_entry(pvp_timer_toggle, "k_experimental_modifiers_pvp_timer"),
+								{ n = G.UIT.R, config = { minh = 0.25 } },
+								create_entry(smallworld_toggle, "k_experimental_modifiers_smallworld"),
+							},
+						},
+						{ n = G.UIT.R },
+						{
+							n = G.UIT.R,
+							config = { align = "cm" },
+							nodes = {
+								MP.UI.get_continue_button(e.config.ref_table.ruleset, e.config.ref_table.mode),
 							},
 						},
 					},

--- a/ui/main_menu/play_button/_mutators_wall.lua
+++ b/ui/main_menu/play_button/_mutators_wall.lua
@@ -1,0 +1,324 @@
+-- The MUTATORS wall and its shared MP.UI builders. Toggles write MP.MODIFIERS
+-- directly (no network) — the host's lobby_options push at start_lobby carries
+-- the serialized list to the guest.
+--
+-- This file owns the wall data, the per-cell toggle handlers, the timer
+-- cycle/blurb logic, and the reusable MP.UI.build_* builders. Both the custom
+-- ruleset editor (custom_ruleset_editor.lua) and any overlay that wants the wall
+-- consume these builders — one source of truth. The cells are toggle "pills"
+-- grouped into themed columns: dim-tinted when off, full category colour when
+-- on, description on hover. Cells recolour live via a per-frame `func` (engine
+-- reads config.colour each draw) so nothing rebuilds.
+
+local function timer_modifier_to_index()
+	if MP.has_modifier("pressure_timer_plus") then return 4 end
+	if MP.has_modifier("pressure_timer") then return 3 end
+	if MP.has_modifier("no_animation_timer") then return 2 end
+	return 1
+end
+
+-- Indices line up with localization ml_mp_modifier_timer_opt: 1=default, 2=no_anim, 3=pressure
+G.FUNCS.change_modifier_timer = function(args)
+	MP.remove_modifier("no_animation_timer")
+	MP.remove_modifier("pressure_timer")
+	MP.remove_modifier("pressure_timer_plus")
+	if args.to_key == 2 then
+		MP.add_modifier("no_animation_timer")
+	elseif args.to_key == 3 then
+		MP.add_modifier("pressure_timer")
+	elseif args.to_key == 4 then
+		MP.add_modifier("pressure_timer")
+		MP.add_modifier("pressure_timer_plus")
+	end
+end
+
+-- One-line blurb per timer option (indices match timer_modifier_to_index).
+-- Shown next to the cycle instead of all four at once; updated live as you cycle.
+local TIMER_BLURBS = {
+	"Regular 150s timer.",
+	"100s timer, animations off.",
+	"100s, no anim, starts at once.",
+	"Pressure, +15s per hand played.",
+}
+
+-- Live-update the timer blurb to match the current cycle selection. Mirrors
+-- display_custom_seed: mutate the child text node and recalculate only on change.
+G.FUNCS.mp_timer_blurb = function(e)
+	local txt = TIMER_BLURBS[timer_modifier_to_index()] or ""
+	if e.children[1] and e.children[1].config.text ~= txt then
+		e.children[1].config.text = txt
+		e.UIBox:recalculate(true)
+	end
+end
+
+-- ---------------------------------------------------------------------------
+-- The wall
+-- ---------------------------------------------------------------------------
+-- View config only — `key` is the layer name (what MP.MODIFIERS stores). Names
+-- and blurbs are inline for now; trivially swappable to localize() later.
+-- Each column shares a colour; cells tint dark when off, bright when on.
+local MUTATOR_WALL = {
+	{
+		name = "ECONOMY",
+		colour = G.C.MONEY,
+		cells = {
+			{ key = "inflation", label = "Inflation", desc = { "Shop prices creep up $1 with", "every card you buy." } },
+			{ key = "no_interest", label = "No Interest", desc = { "Savings earn nothing.", "Spend it or lose the edge." } },
+			{ key = "discard_tax", label = "Discard Tax", desc = { "Every discard costs $1.", "Think before you toss." } },
+			{ key = "frugal", label = "Frugal", desc = { "Unspent discards pay out,", "like leftover hands do." } },
+		},
+	},
+	{
+		name = "MAYHEM",
+		colour = G.C.PURPLE,
+		cells = {
+			{ key = "flipped_cards", label = "Blind Poker", desc = { "Your hand is dealt face-down.", "Play by memory and nerve." } },
+			{ key = "debuff_played_cards", label = "Dead Cards", desc = { "Played cards score zero.", "Jokers are the whole engine." } },
+			{ key = "all_eternal", label = "No Takebacks", desc = { "Every joker is eternal —", "unsellable, undestroyable." } },
+			{ key = "shrinking_hand", label = "Heavy Pockets", desc = { "-1 hand size for every $10", "you're holding. Rich, clumsy." } },
+		},
+	},
+	{
+		name = "HAZARDS",
+		colour = G.C.RED,
+		cells = {
+			{ key = "gambling_opportunity", label = "No Easy Money", desc = { "No Gold or Lucky cards.", "Earn it the hard way." } },
+			{ key = "no_legendaries", label = "No Legends", desc = { "The five legendary jokers", "are out of the pool." } },
+			{ key = "sticker_shop", label = "Risky Shelf", desc = { "Shop stocks eternal, perishable", "and rental jokers. Beware." } },
+			{ key = "chip_cap", label = "Cash Ceiling", desc = { "Chip score can't exceed your", "cash. Greed is the only way up." } },
+		},
+	},
+	{
+		name = "CHAOS",
+		colour = G.C.ORANGE,
+		cells = {
+			{ key = "glass_cannon", label = "Glass Cannon", desc = { "Only 2 hands a round — but", "every hand hits for 4x mult." } },
+			{ key = "smallworld", label = "Small World", desc = { "75% of the pool banned at", "random. Showman always on." } },
+			{ key = "spartan", label = "Spartan", desc = { "No cash from Small or Big", "blinds. Lean times." } },
+			{ key = "pricey_packs", label = "Pricey Packs", desc = { "Booster packs cost more", "for each ante you reach." } },
+		},
+	},
+}
+
+local SOON = {
+	colour = G.C.GREY,
+	cells = {
+		{ key = "pvp_reward_draft", label = "Reward Draft", desc = { "Win a PvP blind, draft 1 of 3", "rewards.", "(coming soon)" } },
+		{ key = "rubber_band", label = "Rubber Band", desc = { "Falling behind grants", "escalating buffs.", "(coming soon)" } },
+		{ key = "score_tax", label = "Score Tax", desc = { "Each hand you play raises", "your opponent's target.", "(coming soon)" } },
+	},
+}
+
+G.FUNCS.mp_toggle_mutator = function(e)
+	local key = e.config.ref_table.key
+	MP.MUTATORS_BLIND = false -- touching anything reveals the wall
+	if MP.has_modifier(key) then
+		MP.remove_modifier(key)
+		play_sound("cardSlide2", 1.1, 0.4)
+	else
+		MP.add_modifier(key)
+		play_sound("cardSlide1", 1.1, 0.5)
+	end
+	e:juice_up(0.2, 0.1)
+end
+
+-- Live recolour: bright when the modifier is active, dim-tinted otherwise.
+-- In blind mode the wall lies — active cells read as off, so you go in blind.
+G.FUNCS.mp_mutator_cell_colour = function(e)
+	local rt = e.config.ref_table
+	local lit = MP.has_modifier(rt.key) and not MP.MUTATORS_BLIND
+	e.config.colour = lit and rt.on or rt.off
+end
+
+-- Roll a fresh random loadout across the whole wall (~1 in 3 odds per knob).
+local function roll_mutators()
+	for _, cat in ipairs(MUTATOR_WALL) do
+		for _, cell in ipairs(cat.cells) do
+			MP.remove_modifier(cell.key)
+			if math.random() < 0.35 then MP.add_modifier(cell.key) end
+		end
+	end
+end
+
+G.FUNCS.mp_randomize_mutators = function(e)
+	MP.MUTATORS_BLIND = false
+	roll_mutators()
+	play_sound("generic1", 1.0, 0.5)
+	e:juice_up(0.3, 0.1)
+end
+
+G.FUNCS.mp_blind_random_mutators = function(e)
+	roll_mutators()
+	MP.MUTATORS_BLIND = true -- keep the roll a secret
+	play_sound("timpani", 1.0, 0.5)
+	e:juice_up(0.3, 0.1)
+end
+
+local function mutator_cell(cell, colour, disabled)
+	local on = colour
+	local off = darken(colour, 0.72)
+	return {
+		n = G.UIT.R,
+		config = { align = "cm", padding = 0.035 },
+		nodes = {
+			{
+				n = G.UIT.C,
+				config = {
+					align = "cm",
+					minw = 2.5,
+					minh = 0.46,
+					padding = 0.06,
+					r = 0.1,
+					emboss = 0.05,
+					hover = true,
+					shadow = not disabled,
+					colour = disabled and G.C.UI.BACKGROUND_INACTIVE or off,
+					button = not disabled and "mp_toggle_mutator" or nil,
+					func = not disabled and "mp_mutator_cell_colour" or nil,
+					ref_table = { key = cell.key, on = on, off = off },
+					tooltip = { title = cell.label, text = cell.desc },
+				},
+				nodes = {
+					{
+						n = G.UIT.T,
+						config = {
+							text = cell.label,
+							scale = 0.34,
+							colour = disabled and G.C.UI.TEXT_INACTIVE or G.C.UI.TEXT_LIGHT,
+						},
+					},
+				},
+			},
+		},
+	}
+end
+
+local function mutator_column(cat)
+	local nodes = {
+		{
+			n = G.UIT.R,
+			config = { align = "cm", padding = 0.04, minh = 0.4 },
+			nodes = { { n = G.UIT.T, config = { text = cat.name, scale = 0.4, colour = cat.colour, shadow = true } } },
+		},
+	}
+	for _, cell in ipairs(cat.cells) do
+		nodes[#nodes + 1] = mutator_cell(cell, cat.colour)
+	end
+	return { n = G.UIT.C, config = { align = "tm", padding = 0.06 }, nodes = nodes }
+end
+
+-- ---------------------------------------------------------------------------
+-- Reusable builders (shared by overlays and the inline custom-ruleset editor —
+-- one source of truth for the wall + timer controls).
+-- ---------------------------------------------------------------------------
+function MP.UI.build_timer_modifier_cycle()
+	return MP.UI.Disableable_Option_Cycle({
+		id = "modifier_timer_option",
+		enabled_ref_table = { val = true },
+		enabled_ref_value = "val",
+		label = localize("k_opts_modifier_timer"),
+		scale = 0.8,
+		options = localize("ml_mp_modifier_timer_opt"),
+		current_option = timer_modifier_to_index(),
+		opt_callback = "change_modifier_timer",
+		minw = 4,
+		w = 4,
+	})
+end
+
+function MP.UI.build_pvp_timer_toggle()
+	return create_toggle({
+		id = "modifier_pvp_timer_toggle",
+		label = localize("b_opts_modifier_pvp_timer"),
+		ref_table = { val = MP.has_modifier("pvp_timer") },
+		ref_value = "val",
+		callback = function(new_val)
+			if new_val then
+				MP.add_modifier("pvp_timer")
+			else
+				MP.remove_modifier("pvp_timer")
+			end
+		end,
+	})
+end
+
+-- The MUTATORS wall block: header + subtitle + themed columns + coming-soon line.
+-- Returns one node (rows stack vertically since they're R children).
+function MP.UI.build_mutators_wall()
+	local columns = {}
+	for _, cat in ipairs(MUTATOR_WALL) do
+		columns[#columns + 1] = mutator_column(cat)
+	end
+	local soon_labels = {}
+	for _, cell in ipairs(SOON.cells) do
+		soon_labels[#soon_labels + 1] = cell.label
+	end
+	local soon_line = "coming soon · " .. table.concat(soon_labels, " · ")
+	return {
+		n = G.UIT.R,
+		config = { align = "cm" },
+		nodes = {
+			{
+				n = G.UIT.R,
+				config = { align = "cm", padding = 0.02 },
+				nodes = { { n = G.UIT.T, config = { text = "MUTATORS", scale = 0.5, colour = G.C.UI.TEXT_LIGHT, shadow = true } } },
+			},
+			{
+				n = G.UIT.R,
+				config = { align = "cm", padding = 0.02 },
+				nodes = { { n = G.UIT.T, config = { text = "stack freely · hover for details", scale = 0.3, colour = G.C.UI.TEXT_INACTIVE } } },
+			},
+			{ n = G.UIT.R, config = { align = "cm", padding = 0.04 }, nodes = columns },
+			{ n = G.UIT.R, config = { minh = 0.06 } },
+			{
+				n = G.UIT.R,
+				config = { align = "cm", padding = 0.02 },
+				nodes = { { n = G.UIT.T, config = { text = soon_line, scale = 0.3, colour = G.C.UI.TEXT_INACTIVE } } },
+			},
+		},
+	}
+end
+
+-- Randomize / Blind Random pair (operate on MP.MODIFIERS via the global FUNCS).
+function MP.UI.build_mutator_randomize_row()
+	return {
+		n = G.UIT.R,
+		config = { align = "cm", padding = 0.05 },
+		nodes = {
+			{
+				n = G.UIT.C,
+				config = { align = "cm", padding = 0.05 },
+				nodes = {
+					UIBox_button({
+						id = "mp_randomize_mutators_btn",
+						button = "mp_randomize_mutators",
+						label = { "Randomize" },
+						colour = G.C.ORANGE,
+						minw = 2.8,
+						minh = 0.7,
+						scale = 0.4,
+						hover = true,
+						shadow = true,
+					}),
+				},
+			},
+			{
+				n = G.UIT.C,
+				config = { align = "cm", padding = 0.05 },
+				nodes = {
+					UIBox_button({
+						id = "mp_blind_random_mutators_btn",
+						button = "mp_blind_random_mutators",
+						label = { "Blind Random" },
+						colour = G.C.PURPLE,
+						minw = 2.8,
+						minh = 0.7,
+						scale = 0.4,
+						hover = true,
+						shadow = true,
+					}),
+				},
+			},
+		},
+	}
+end

--- a/ui/main_menu/play_button/_mutators_wall.lua
+++ b/ui/main_menu/play_button/_mutators_wall.lua
@@ -64,7 +64,7 @@ local MUTATOR_WALL = {
 		cells = {
 			{ key = "inflation", label = "Inflation", desc = { "Shop prices creep up $1 with", "every card you buy." } },
 			{ key = "no_interest", label = "No Interest", desc = { "Savings earn nothing.", "Spend it or lose the edge." } },
-			{ key = "discard_tax", label = "Discard Tax", desc = { "Every discard costs $1.", "Think before you toss." } },
+			{ key = "discard_tax", label = "Discard Tax", desc = { "Every discard costs $1." } },
 			{ key = "frugal", label = "Frugal", desc = { "Unspent discards pay out,", "like leftover hands do." } },
 		},
 	},
@@ -75,16 +75,16 @@ local MUTATOR_WALL = {
 			{ key = "flipped_cards", label = "Blind Poker", desc = { "Your hand is dealt face-down.", "Play by memory and nerve." } },
 			{ key = "debuff_played_cards", label = "Dead Cards", desc = { "Played cards score zero.", "Jokers are the whole engine." } },
 			{ key = "all_eternal", label = "No Takebacks", desc = { "Every joker is eternal —", "unsellable, undestroyable." } },
-			{ key = "shrinking_hand", label = "Heavy Pockets", desc = { "-1 hand size for every $10", "you're holding. Rich, clumsy." } },
+			{ key = "shrinking_hand", label = "Heavy Pockets", desc = { "-1 hand size for every $10", "you're holding." } },
 		},
 	},
 	{
 		name = "HAZARDS",
 		colour = G.C.RED,
 		cells = {
-			{ key = "gambling_opportunity", label = "No Easy Money", desc = { "No Gold or Lucky cards.", "Earn it the hard way." } },
-			{ key = "no_legendaries", label = "No Legends", desc = { "The five legendary jokers", "are out of the pool." } },
-			{ key = "sticker_shop", label = "Risky Shelf", desc = { "Shop stocks eternal, perishable", "and rental jokers. Beware." } },
+			{ key = "gambling_opportunity", label = "No Easy Money", desc = { "No Gold or Lucky cards." } },
+			{ key = "no_rares", label = "No Rares", desc = { "Rare jokers are out", "of the pool." } },
+			{ key = "sticker_shop", label = "Risky Shelf", desc = { "Shop stocks eternal, perishable", "and rental jokers." } },
 			{ key = "chip_cap", label = "Cash Ceiling", desc = { "Chip score can't exceed your", "cash. Greed is the only way up." } },
 		},
 	},
@@ -94,7 +94,7 @@ local MUTATOR_WALL = {
 		cells = {
 			{ key = "glass_cannon", label = "Glass Cannon", desc = { "Only 2 hands a round — but", "every hand hits for 4x mult." } },
 			{ key = "smallworld", label = "Small World", desc = { "75% of the pool banned at", "random. Showman always on." } },
-			{ key = "spartan", label = "Spartan", desc = { "No cash from Small or Big", "blinds. Lean times." } },
+			{ key = "spartan", label = "Spartan", desc = { "No cash from Small or Big", "blinds." } },
 			{ key = "pricey_packs", label = "Pricey Packs", desc = { "Booster packs cost more", "for each ante you reach." } },
 		},
 	},

--- a/ui/main_menu/play_button/custom_ruleset_editor.lua
+++ b/ui/main_menu/play_button/custom_ruleset_editor.lua
@@ -162,71 +162,6 @@ G.FUNCS.mp_custom_open_collection = function(e)
 end
 
 
-local SUBMIT = {
-	form_id = "REPLACE_WITH_FORM_ID",
-	entry = "entry.000000000", -- single long-answer field; holds the whole JSON blob
-}
-
-local json = require("json")
-
-local function urlencode(str)
-	return (tostring(str or ""):gsub("\n", "\r\n"):gsub("([^%w _%%%-%.~])", function(c)
-		return string.format("%%%02X", string.byte(c))
-	end):gsub(" ", "+"))
-end
-
-local function ensure_http_thread()
-	if MP.CUSTOM._http_thread then return end
-	MP.CUSTOM._http_thread = love.thread.newThread([[
-		local ok, https = pcall(require, "https")
-		local CHANNEL = love.thread.getChannel("mp_custom_http")
-		while true do
-			local req = CHANNEL:demand()
-			if req and ok then
-				pcall(https.request, req.url, {
-					method = "POST",
-					data = req.body,
-					headers = { ["Content-Type"] = "application/x-www-form-urlencoded" },
-				})
-			end
-		end
-	]])
-	MP.CUSTOM._http_thread:start()
-end
-
-function MP.CUSTOM.submit_dream(draft)
-	if not draft then return end
-	if SUBMIT.form_id == "REPLACE_WITH_FORM_ID" then
-		sendDebugMessage("custom ruleset submit: Google Form not configured (stub)", "MULTIPLAYER")
-		return
-	end
-	ensure_http_thread()
-	local mod = SMODS.Mods["Multiplayer"]
-	local payload = json.encode({
-		name = draft.name,
-		base = draft.base,
-		modifiers = MP.MODIFIERS, -- live, edited via the shared modifiers overlay
-		scalars = draft.scalars,
-		banned_jokers = draft.banned_jokers,
-		banned_consumables = draft.banned_consumables,
-		banned_vouchers = draft.banned_vouchers,
-		user = mod and mod.config and mod.config.username,
-		version = mod and mod.version,
-	})
-	love.thread.getChannel("mp_custom_http"):push({
-		url = "https://docs.google.com/forms/d/e/" .. SUBMIT.form_id .. "/formResponse",
-		body = SUBMIT.entry .. "=" .. urlencode(payload),
-	})
-end
-
-G.FUNCS.mp_custom_submit_dream = function(e)
-	MP.CUSTOM.submit_dream(MP.CUSTOM.draft)
-	MP.CUSTOM.submitted = true
-	play_sound("generic1", 1.0, 0.6)
-	if e then e:juice_up(0.3, 0.1) end
-	G.FUNCS.mp_custom_back_to_editor(e) -- re-render so the button reads "Sent"
-end
-
 -- ---------------------------------------------------------------------------
 -- Tab content
 -- ---------------------------------------------------------------------------
@@ -339,31 +274,11 @@ function MP.UI.build_custom_ruleset_editor(mode)
 		MP.UI.build_mutator_randomize_row(),
 	}
 
-	local submit_node = MP.CUSTOM.submitted
-			and soon_pill("Sent! thanks")
-		or {
-			n = G.UIT.C,
-			config = { align = "cm", padding = 0.06 },
-			nodes = {
-				UIBox_button({
-					id = "mp_custom_submit_btn",
-					button = "mp_custom_submit_dream",
-					label = { "Submit your dream ruleset" },
-					colour = G.C.GREEN,
-					minw = 4.5,
-					minh = 0.85,
-					scale = 0.45,
-					hover = true,
-					shadow = true,
-				}),
-			},
-		}
 	local actions = {
 		n = G.UIT.R,
 		config = { align = "cm", padding = 0.12 },
 		nodes = {
 			{ n = G.UIT.C, config = { align = "cm", padding = 0.06 }, nodes = { soon_pill("Save & Play") } },
-			submit_node,
 		},
 	}
 

--- a/ui/main_menu/play_button/custom_ruleset_editor.lua
+++ b/ui/main_menu/play_button/custom_ruleset_editor.lua
@@ -1,26 +1,9 @@
--- ============================================================================
--- Custom ruleset editor — bespoke tab in ruleset selection (FIRST CUT)
--- ============================================================================
--- Pure UI for now: pick a content set, toggle modifier layers, nudge a couple
--- scalars, and ban jokers by browsing the vanilla Collection. Everything lives
--- on an in-memory draft (MP.CUSTOM.draft). No persistence, no wire, no inject
--- yet — the point is to *see* the ban picker + knobs working.
---
--- Deliberately does NOT use loc keys: every label is a raw string so we can
--- iterate on the layout without touching localization.
--- ============================================================================
-
 MP.CUSTOM = MP.CUSTOM or {}
 
--- Content sets re-rework the same cards, so they're mutually exclusive (radio).
 local CONTENT_SETS = { "none", "standard", "experimental", "classic" }
--- Modifiers are edited inline in the right panel via the shared MUTATORS wall
--- (MP.UI.build_mutators_wall et al, from _modifiers_overlay.lua). They drive the
--- runtime MP.MODIFIERS list. A future save would snapshot MP.MODIFIERS into the draft.
 local LIVES_OPTIONS = { 1, 2, 3, 4, 5, 6, 7, 8 }
 local PVP_START_OPTIONS = { 1, 2, 3, 4, 5, 6, 7, 8 }
 
--- Option cycles render the chosen value as text-node text, which wants strings.
 local function as_strings(nums)
 	local out = {}
 	for i, n in ipairs(nums) do
@@ -32,13 +15,11 @@ local LIVES_LABELS = as_strings(LIVES_OPTIONS)
 local PVP_START_LABELS = as_strings(PVP_START_OPTIONS)
 
 -- ---------------------------------------------------------------------------
--- Draft model (in-memory; this IS the eventual disk/wire schema)
--- ---------------------------------------------------------------------------
 function MP.CUSTOM.new_draft()
 	return {
 		name = "My Ruleset",
-		base = "standard", -- one of CONTENT_SETS
-		modifiers = {}, -- snapshot of MP.MODIFIERS at save time (edited via the modifiers overlay)
+		base = "standard", -- content_sets
+		modifiers = {}, -- snapshotted modifiers
 		banned_jokers = {},
 		banned_consumables = {},
 		banned_vouchers = {},
@@ -46,8 +27,6 @@ function MP.CUSTOM.new_draft()
 	}
 end
 
--- nil when not editing; the collection hooks key off this so they no-op
--- everywhere else in the game.
 MP.CUSTOM.draft = nil
 
 local function list_has(list, key)
@@ -73,9 +52,6 @@ local function index_of(list, value, default)
 	return default or 1
 end
 
--- ---------------------------------------------------------------------------
--- Ban set helpers (set-semantics over the draft's per-category arrays)
--- ---------------------------------------------------------------------------
 local function bucket_for(draft, set)
 	if set == "Joker" then return draft.banned_jokers end
 	if set == "Tarot" or set == "Planet" or set == "Spectral" then return draft.banned_consumables end
@@ -107,11 +83,6 @@ function MP.CUSTOM.toggle_ban(card)
 	end
 end
 
--- ---------------------------------------------------------------------------
--- Collection picker — paint the draft's bans onto the open Collection page,
--- DELETE toggles the hovered card. Lifted from the mockup, validated against
--- SMODS.card_collection_UIBox / SMODS_card_collection_page paging.
--- ---------------------------------------------------------------------------
 function MP.CUSTOM.debuff_collection_page()
 	if not (G.your_collection and MP.CUSTOM.draft) then return end
 	for i = 1, #G.your_collection do
@@ -140,11 +111,7 @@ function G.FUNCS.option_cycle(e)
 	return ret
 end
 
--- The joker collection's Back button is hardcoded to `your_collection` (the
--- collection hub). When we opened it from the editor to pick bans, intercept
--- that one press and route back to the Custom tab instead. The flag is set only
--- for the editor's open and cleared on the way out, so the hub works normally
--- everywhere else.
+-- hijack the collection when we're in the joker ban
 local _your_collection_ref = G.FUNCS.your_collection
 G.FUNCS.your_collection = function(e)
 	if MP.CUSTOM.editing_bans then
@@ -160,7 +127,7 @@ G.FUNCS.mp_custom_back_to_editor = function(e)
 	})
 end
 
--- Press DELETE while hovering a collection card to toggle its ban.
+-- credit to @Aaal for MPCustomBans which I was heavily inspired by
 SMODS.Keybind({
 	key = "mp_custom_ban",
 	key_pressed = "delete",
@@ -173,9 +140,6 @@ SMODS.Keybind({
 	end,
 })
 
--- ---------------------------------------------------------------------------
--- Knob callbacks (mutate the draft in place; pure state for now)
--- ---------------------------------------------------------------------------
 G.FUNCS.mp_custom_set_base = function(args)
 	if MP.CUSTOM.draft and args and args.to_key then MP.CUSTOM.draft.base = CONTENT_SETS[args.to_key] end
 end
@@ -193,25 +157,11 @@ G.FUNCS.mp_custom_set_pvp_start = function(args)
 end
 
 G.FUNCS.mp_custom_open_collection = function(e)
-	-- Drop into the vanilla joker collection; the hooks above paint the current
-	-- ban set and DELETE toggles entries. The flag makes the collection's Back
-	-- button route to the Custom tab (see the your_collection wrap above).
 	MP.CUSTOM.editing_bans = true
 	G.FUNCS.your_collection_jokers(e)
 end
 
--- ---------------------------------------------------------------------------
--- "Submit your dream ruleset" — teaser interest capture (stub)
--- ---------------------------------------------------------------------------
--- Custom rulesets aren't wired to anything yet. But while it's a teaser we can
--- still learn what people *want* to build: fire-and-forget the draft to a Google
--- Form (responses land in a Sheet — no backend to stand up). Mirrors Balatro's
--- own crash reporter — a persistent thread requires `https` and pumps requests
--- off a channel, so the main thread never blocks and a missing lib can't crash.
---
--- TODO: fill these in. Make a Google Form with one long-answer question, grab the
--- "Get pre-filled link" URL: the form id is the e/<id> in /forms/d/e/<id>/, and
--- the field is the entry.<digits> in the query string.
+
 local SUBMIT = {
 	form_id = "REPLACE_WITH_FORM_ID",
 	entry = "entry.000000000", -- single long-answer field; holds the whole JSON blob
@@ -314,7 +264,7 @@ local function coming_soon_ribbon()
 	}
 end
 
--- Disabled "coming soon" pill, matching the mutator wall's inert-cell look.
+
 local function soon_pill(label)
 	return {
 		n = G.UIT.C,
@@ -375,9 +325,6 @@ function MP.UI.build_custom_ruleset_editor(mode)
 	knobs[#knobs + 1] = text_row("Banned jokers: " .. tostring(#d.banned_jokers), 0.32, G.C.UI.TEXT_INACTIVE)
 	knobs[#knobs + 1] = text_row("(hover a card, press DELETE)", 0.28, G.C.UI.TEXT_DARK)
 
-	-- right panel: the modifiers live here now — the same MUTATORS wall the
-	-- standalone overlay shows, plus the compact timer/PvP controls and the
-	-- randomize pair. All drive MP.MODIFIERS, so the editor and lobby agree.
 	local modifiers_panel = {
 		{
 			n = G.UIT.R,
@@ -392,7 +339,6 @@ function MP.UI.build_custom_ruleset_editor(mode)
 		MP.UI.build_mutator_randomize_row(),
 	}
 
-	-- action row: play is honestly disabled; submitting your dream combo is live.
 	local submit_node = MP.CUSTOM.submitted
 			and soon_pill("Sent! thanks")
 		or {

--- a/ui/main_menu/play_button/custom_ruleset_editor.lua
+++ b/ui/main_menu/play_button/custom_ruleset_editor.lua
@@ -1,0 +1,444 @@
+-- ============================================================================
+-- Custom ruleset editor — bespoke tab in ruleset selection (FIRST CUT)
+-- ============================================================================
+-- Pure UI for now: pick a content set, toggle modifier layers, nudge a couple
+-- scalars, and ban jokers by browsing the vanilla Collection. Everything lives
+-- on an in-memory draft (MP.CUSTOM.draft). No persistence, no wire, no inject
+-- yet — the point is to *see* the ban picker + knobs working.
+--
+-- Deliberately does NOT use loc keys: every label is a raw string so we can
+-- iterate on the layout without touching localization.
+-- ============================================================================
+
+MP.CUSTOM = MP.CUSTOM or {}
+
+-- Content sets re-rework the same cards, so they're mutually exclusive (radio).
+local CONTENT_SETS = { "none", "standard", "experimental", "classic" }
+-- Modifiers are edited inline in the right panel via the shared MUTATORS wall
+-- (MP.UI.build_mutators_wall et al, from _modifiers_overlay.lua). They drive the
+-- runtime MP.MODIFIERS list. A future save would snapshot MP.MODIFIERS into the draft.
+local LIVES_OPTIONS = { 1, 2, 3, 4, 5, 6, 7, 8 }
+local PVP_START_OPTIONS = { 1, 2, 3, 4, 5, 6, 7, 8 }
+
+-- Option cycles render the chosen value as text-node text, which wants strings.
+local function as_strings(nums)
+	local out = {}
+	for i, n in ipairs(nums) do
+		out[i] = tostring(n)
+	end
+	return out
+end
+local LIVES_LABELS = as_strings(LIVES_OPTIONS)
+local PVP_START_LABELS = as_strings(PVP_START_OPTIONS)
+
+-- ---------------------------------------------------------------------------
+-- Draft model (in-memory; this IS the eventual disk/wire schema)
+-- ---------------------------------------------------------------------------
+function MP.CUSTOM.new_draft()
+	return {
+		name = "My Ruleset",
+		base = "standard", -- one of CONTENT_SETS
+		modifiers = {}, -- snapshot of MP.MODIFIERS at save time (edited via the modifiers overlay)
+		banned_jokers = {},
+		banned_consumables = {},
+		banned_vouchers = {},
+		scalars = { starting_lives = 4, pvp_start_round = 2 },
+	}
+end
+
+-- nil when not editing; the collection hooks key off this so they no-op
+-- everywhere else in the game.
+MP.CUSTOM.draft = nil
+
+local function list_has(list, key)
+	for _, v in ipairs(list) do
+		if v == key then return true end
+	end
+	return false
+end
+
+local function list_remove(list, key)
+	for i, v in ipairs(list) do
+		if v == key then
+			table.remove(list, i)
+			return
+		end
+	end
+end
+
+local function index_of(list, value, default)
+	for i, v in ipairs(list) do
+		if v == value then return i end
+	end
+	return default or 1
+end
+
+-- ---------------------------------------------------------------------------
+-- Ban set helpers (set-semantics over the draft's per-category arrays)
+-- ---------------------------------------------------------------------------
+local function bucket_for(draft, set)
+	if set == "Joker" then return draft.banned_jokers end
+	if set == "Tarot" or set == "Planet" or set == "Spectral" then return draft.banned_consumables end
+	if set == "Voucher" then return draft.banned_vouchers end
+	return nil
+end
+
+function MP.CUSTOM.is_banned(key)
+	local d = MP.CUSTOM.draft
+	if not d then return false end
+	return list_has(d.banned_jokers, key)
+		or list_has(d.banned_consumables, key)
+		or list_has(d.banned_vouchers, key)
+end
+
+function MP.CUSTOM.toggle_ban(card)
+	local d = MP.CUSTOM.draft
+	if not d then return end
+	local set = card.config.center.set
+	local key = card.config.center.key
+	local list = bucket_for(d, set)
+	if not list then return end
+	if list_has(list, key) then
+		list_remove(list, key)
+		card.debuff = false
+	else
+		list[#list + 1] = key
+		card.debuff = true
+	end
+end
+
+-- ---------------------------------------------------------------------------
+-- Collection picker — paint the draft's bans onto the open Collection page,
+-- DELETE toggles the hovered card. Lifted from the mockup, validated against
+-- SMODS.card_collection_UIBox / SMODS_card_collection_page paging.
+-- ---------------------------------------------------------------------------
+function MP.CUSTOM.debuff_collection_page()
+	if not (G.your_collection and MP.CUSTOM.draft) then return end
+	for i = 1, #G.your_collection do
+		for _, v in pairs(G.your_collection[i].cards) do
+			if v.config and v.config.center_key and MP.CUSTOM.is_banned(v.config.center_key) then v.debuff = true end
+		end
+	end
+end
+
+-- Re-paint every time a collection UIBox is (re)built...
+local _cc_ref = SMODS.card_collection_UIBox
+function SMODS.card_collection_UIBox(_pool, rows, args)
+	local ret = _cc_ref(_pool, rows, args)
+	MP.CUSTOM.debuff_collection_page()
+	return ret
+end
+
+-- ...and every time the player pages within a collection (SMODS paging fires
+-- option_cycle with this opt_callback).
+local _oc_ref = G.FUNCS.option_cycle
+function G.FUNCS.option_cycle(e)
+	local ret = _oc_ref(e)
+	if e.config.ref_table and e.config.ref_table.opt_callback == "SMODS_card_collection_page" then
+		MP.CUSTOM.debuff_collection_page()
+	end
+	return ret
+end
+
+-- The joker collection's Back button is hardcoded to `your_collection` (the
+-- collection hub). When we opened it from the editor to pick bans, intercept
+-- that one press and route back to the Custom tab instead. The flag is set only
+-- for the editor's open and cleared on the way out, so the hub works normally
+-- everywhere else.
+local _your_collection_ref = G.FUNCS.your_collection
+G.FUNCS.your_collection = function(e)
+	if MP.CUSTOM.editing_bans then
+		MP.CUSTOM.editing_bans = nil
+		return G.FUNCS.mp_custom_back_to_editor(e)
+	end
+	return _your_collection_ref(e)
+end
+
+G.FUNCS.mp_custom_back_to_editor = function(e)
+	G.FUNCS.overlay_menu({
+		definition = G.UIDEF.ruleset_selection_tabs(MP.CUSTOM.editor_mode or "mp", "Custom"),
+	})
+end
+
+-- Press DELETE while hovering a collection card to toggle its ban.
+SMODS.Keybind({
+	key = "mp_custom_ban",
+	key_pressed = "delete",
+	action = function(self)
+		if not MP.CUSTOM.draft then return end
+		local target = G.CONTROLLER.hovering and G.CONTROLLER.hovering.target
+		if not (target and target.config and target.config.center) then return end
+		local area = target.area
+		if area and area.config and area.config.collection then MP.CUSTOM.toggle_ban(target) end
+	end,
+})
+
+-- ---------------------------------------------------------------------------
+-- Knob callbacks (mutate the draft in place; pure state for now)
+-- ---------------------------------------------------------------------------
+G.FUNCS.mp_custom_set_base = function(args)
+	if MP.CUSTOM.draft and args and args.to_key then MP.CUSTOM.draft.base = CONTENT_SETS[args.to_key] end
+end
+
+G.FUNCS.mp_custom_set_lives = function(args)
+	if MP.CUSTOM.draft and args and args.to_key then
+		MP.CUSTOM.draft.scalars.starting_lives = LIVES_OPTIONS[args.to_key]
+	end
+end
+
+G.FUNCS.mp_custom_set_pvp_start = function(args)
+	if MP.CUSTOM.draft and args and args.to_key then
+		MP.CUSTOM.draft.scalars.pvp_start_round = PVP_START_OPTIONS[args.to_key]
+	end
+end
+
+G.FUNCS.mp_custom_open_collection = function(e)
+	-- Drop into the vanilla joker collection; the hooks above paint the current
+	-- ban set and DELETE toggles entries. The flag makes the collection's Back
+	-- button route to the Custom tab (see the your_collection wrap above).
+	MP.CUSTOM.editing_bans = true
+	G.FUNCS.your_collection_jokers(e)
+end
+
+-- ---------------------------------------------------------------------------
+-- "Submit your dream ruleset" — teaser interest capture (stub)
+-- ---------------------------------------------------------------------------
+-- Custom rulesets aren't wired to anything yet. But while it's a teaser we can
+-- still learn what people *want* to build: fire-and-forget the draft to a Google
+-- Form (responses land in a Sheet — no backend to stand up). Mirrors Balatro's
+-- own crash reporter — a persistent thread requires `https` and pumps requests
+-- off a channel, so the main thread never blocks and a missing lib can't crash.
+--
+-- TODO: fill these in. Make a Google Form with one long-answer question, grab the
+-- "Get pre-filled link" URL: the form id is the e/<id> in /forms/d/e/<id>/, and
+-- the field is the entry.<digits> in the query string.
+local SUBMIT = {
+	form_id = "REPLACE_WITH_FORM_ID",
+	entry = "entry.000000000", -- single long-answer field; holds the whole JSON blob
+}
+
+local json = require("json")
+
+local function urlencode(str)
+	return (tostring(str or ""):gsub("\n", "\r\n"):gsub("([^%w _%%%-%.~])", function(c)
+		return string.format("%%%02X", string.byte(c))
+	end):gsub(" ", "+"))
+end
+
+local function ensure_http_thread()
+	if MP.CUSTOM._http_thread then return end
+	MP.CUSTOM._http_thread = love.thread.newThread([[
+		local ok, https = pcall(require, "https")
+		local CHANNEL = love.thread.getChannel("mp_custom_http")
+		while true do
+			local req = CHANNEL:demand()
+			if req and ok then
+				pcall(https.request, req.url, {
+					method = "POST",
+					data = req.body,
+					headers = { ["Content-Type"] = "application/x-www-form-urlencoded" },
+				})
+			end
+		end
+	]])
+	MP.CUSTOM._http_thread:start()
+end
+
+function MP.CUSTOM.submit_dream(draft)
+	if not draft then return end
+	if SUBMIT.form_id == "REPLACE_WITH_FORM_ID" then
+		sendDebugMessage("custom ruleset submit: Google Form not configured (stub)", "MULTIPLAYER")
+		return
+	end
+	ensure_http_thread()
+	local mod = SMODS.Mods["Multiplayer"]
+	local payload = json.encode({
+		name = draft.name,
+		base = draft.base,
+		modifiers = MP.MODIFIERS, -- live, edited via the shared modifiers overlay
+		scalars = draft.scalars,
+		banned_jokers = draft.banned_jokers,
+		banned_consumables = draft.banned_consumables,
+		banned_vouchers = draft.banned_vouchers,
+		user = mod and mod.config and mod.config.username,
+		version = mod and mod.version,
+	})
+	love.thread.getChannel("mp_custom_http"):push({
+		url = "https://docs.google.com/forms/d/e/" .. SUBMIT.form_id .. "/formResponse",
+		body = SUBMIT.entry .. "=" .. urlencode(payload),
+	})
+end
+
+G.FUNCS.mp_custom_submit_dream = function(e)
+	MP.CUSTOM.submit_dream(MP.CUSTOM.draft)
+	MP.CUSTOM.submitted = true
+	play_sound("generic1", 1.0, 0.6)
+	if e then e:juice_up(0.3, 0.1) end
+	G.FUNCS.mp_custom_back_to_editor(e) -- re-render so the button reads "Sent"
+end
+
+-- ---------------------------------------------------------------------------
+-- Tab content
+-- ---------------------------------------------------------------------------
+local function text_row(str, scale, colour)
+	return {
+		n = G.UIT.R,
+		config = { align = "cm", padding = 0.04 },
+		nodes = {
+			{ n = G.UIT.T, config = { text = str, scale = scale or 0.4, colour = colour or G.C.UI.TEXT_LIGHT } },
+		},
+	}
+end
+
+local function knob_row(node)
+	return { n = G.UIT.R, config = { align = "cm", padding = 0.08 }, nodes = { node } }
+end
+
+-- COMING SOON banner across the top of the editor.
+local function coming_soon_ribbon()
+	return {
+		n = G.UIT.R,
+		config = { align = "cm", padding = 0.12, r = 0.1, colour = G.C.BOOSTER, emboss = 0.05, minw = 15 },
+		nodes = {
+			{
+				n = G.UIT.R,
+				config = { align = "cm" },
+				nodes = {
+					{
+						n = G.UIT.T,
+						config = { text = "CUSTOM RULESETS - COMING SOON", scale = 0.55, colour = G.C.UI.TEXT_LIGHT, shadow = true },
+					},
+				},
+			},
+		},
+	}
+end
+
+-- Disabled "coming soon" pill, matching the mutator wall's inert-cell look.
+local function soon_pill(label)
+	return {
+		n = G.UIT.C,
+		config = { align = "cm", minw = 4.5, minh = 0.85, padding = 0.08, r = 0.1, emboss = 0.05, colour = G.C.UI.BACKGROUND_INACTIVE },
+		nodes = {
+			{ n = G.UIT.R, config = { align = "cm" }, nodes = { { n = G.UIT.T, config = { text = label, scale = 0.45, colour = G.C.UI.TEXT_INACTIVE } } } },
+			{ n = G.UIT.R, config = { align = "cm" }, nodes = { { n = G.UIT.T, config = { text = "coming soon", scale = 0.3, colour = G.C.UI.TEXT_INACTIVE } } } },
+		},
+	}
+end
+
+function MP.UI.build_custom_ruleset_editor(mode)
+	MP.CUSTOM.editor_mode = mode -- so the ban picker's Back knows where to return
+	MP.CUSTOM.draft = MP.CUSTOM.draft or MP.CUSTOM.new_draft()
+	local d = MP.CUSTOM.draft
+
+	local knobs = {}
+
+	-- content set radio
+	knobs[#knobs + 1] = knob_row(create_option_cycle({
+		label = "Content set",
+		scale = 0.8,
+		options = CONTENT_SETS,
+		current_option = index_of(CONTENT_SETS, d.base, 2),
+		opt_callback = "mp_custom_set_base",
+		w = 4,
+	}))
+
+	-- scalars
+	knobs[#knobs + 1] = knob_row(create_option_cycle({
+		label = "Starting lives",
+		scale = 0.8,
+		options = LIVES_LABELS,
+		current_option = index_of(LIVES_OPTIONS, d.scalars.starting_lives, 4),
+		opt_callback = "mp_custom_set_lives",
+		w = 4,
+	}))
+	knobs[#knobs + 1] = knob_row(create_option_cycle({
+		label = "PvP start ante",
+		scale = 0.8,
+		options = PVP_START_LABELS,
+		current_option = index_of(PVP_START_OPTIONS, d.scalars.pvp_start_round, 2),
+		opt_callback = "mp_custom_set_pvp_start",
+		w = 4,
+	}))
+
+	-- edit-bans button
+	knobs[#knobs + 1] = knob_row(UIBox_button({
+		button = "mp_custom_open_collection",
+		label = { "Edit joker bans" },
+		minw = 4,
+		minh = 0.8,
+		scale = 0.45,
+		colour = G.C.RED,
+		hover = true,
+		shadow = true,
+	}))
+	knobs[#knobs + 1] = text_row("Banned jokers: " .. tostring(#d.banned_jokers), 0.32, G.C.UI.TEXT_INACTIVE)
+	knobs[#knobs + 1] = text_row("(hover a card, press DELETE)", 0.28, G.C.UI.TEXT_DARK)
+
+	-- right panel: the modifiers live here now — the same MUTATORS wall the
+	-- standalone overlay shows, plus the compact timer/PvP controls and the
+	-- randomize pair. All drive MP.MODIFIERS, so the editor and lobby agree.
+	local modifiers_panel = {
+		{
+			n = G.UIT.R,
+			config = { align = "cm", padding = 0.04 },
+			nodes = {
+				{ n = G.UIT.C, config = { align = "cm", padding = 0.1 }, nodes = { MP.UI.build_timer_modifier_cycle() } },
+				{ n = G.UIT.C, config = { align = "cm", padding = 0.1 }, nodes = { MP.UI.build_pvp_timer_toggle() } },
+			},
+		},
+		MP.UI.build_mutators_wall(),
+		{ n = G.UIT.R, config = { minh = 0.06 } },
+		MP.UI.build_mutator_randomize_row(),
+	}
+
+	-- action row: play is honestly disabled; submitting your dream combo is live.
+	local submit_node = MP.CUSTOM.submitted
+			and soon_pill("Sent! thanks")
+		or {
+			n = G.UIT.C,
+			config = { align = "cm", padding = 0.06 },
+			nodes = {
+				UIBox_button({
+					id = "mp_custom_submit_btn",
+					button = "mp_custom_submit_dream",
+					label = { "Submit your dream ruleset" },
+					colour = G.C.GREEN,
+					minw = 4.5,
+					minh = 0.85,
+					scale = 0.45,
+					hover = true,
+					shadow = true,
+				}),
+			},
+		}
+	local actions = {
+		n = G.UIT.R,
+		config = { align = "cm", padding = 0.12 },
+		nodes = {
+			{ n = G.UIT.C, config = { align = "cm", padding = 0.06 }, nodes = { soon_pill("Save & Play") } },
+			submit_node,
+		},
+	}
+
+	return {
+		n = G.UIT.ROOT,
+		config = { align = "cm", colour = G.C.CLEAR },
+		nodes = {
+			coming_soon_ribbon(),
+			{
+				n = G.UIT.R,
+				config = { align = "cm" },
+				nodes = {
+					{ n = G.UIT.C, config = { align = "tm", minh = 6, minw = 5, padding = 0.1 }, nodes = knobs },
+					{
+						n = G.UIT.C,
+						config = { align = "tm", minh = 6, minw = 10, padding = 0.15, r = 0.1, colour = G.C.BLACK },
+						nodes = modifiers_panel,
+					},
+				},
+			},
+			actions,
+		},
+	}
+end

--- a/ui/main_menu/play_button/ruleset_selection.lua
+++ b/ui/main_menu/play_button/ruleset_selection.lua
@@ -87,7 +87,7 @@ local rulesets_tabs = {
 	},
 }
 
-function G.UIDEF.ruleset_selection_tabs(mode)
+function G.UIDEF.ruleset_selection_tabs(mode, chosen_label)
 	local tabs_schema = rulesets_tabs[mode] or rulesets_tabs.default
 	local tabs = {}
 	for _, item in ipairs(tabs_schema) do
@@ -98,7 +98,25 @@ function G.UIDEF.ruleset_selection_tabs(mode)
 			end,
 		})
 	end
-	tabs[1].chosen = true
+	-- Bespoke custom-ruleset editor tab (raw strings, no loc keys yet).
+	if MP.UI.build_custom_ruleset_editor then
+		table.insert(tabs, {
+			label = "Custom",
+			tab_definition_function = function()
+				return MP.UI.build_custom_ruleset_editor(mode)
+			end,
+		})
+	end
+	-- Open on a specific tab when asked (e.g. returning from the ban picker),
+	-- otherwise default to the first.
+	local chose = false
+	if chosen_label then
+		for _, tab in ipairs(tabs) do
+			tab.chosen = tab.label == chosen_label
+			if tab.chosen then chose = true end
+		end
+	end
+	if not chose then tabs[1].chosen = true end
 	local t = create_UIBox_generic_options({
 		back_func = "play_options",
 		contents = {


### PR DESCRIPTION
### Why

The branch is called `custom-rulesets-to-disk`. This is everything except the disk.

### What this does

Adds a Custom tab to ruleset selection: content-set radio, lives/PvP-start scalars, a joker-ban picker (hover a card, press DELETE - collection hijack, credit Aaal), and a mutators wall. The mutators are the real work — most are pure-data layers mapping straight onto engine-native `G.GAME.modifiers` flags Balatro already reads (inflation, no-interest, flipped cards, chip cap, shrinking hand…), so they're deterministic across both clients with zero new sync. Three need hooks and ship stubbed-but-registered (reward draft, rubber-band, score tax); Glass Cannon is actually built (fewer hands, flat xmult on `final_scoring_step`). `Save & Play` is a "coming soon" pill, and the whole tab wears a COMING SOON ribbon, because none of this persists yet.

### Test plan

- [x] Open Play → Custom, toggle every knob, confirm nothing crashes and nothing saves. That's the feature.