### PR TITLE
feat(lobby): warn players on Multiplayer version mismatch

### DIFF
--- a/lib/matchmaking.lua
+++ b/lib/matchmaking.lua
@@ -178,6 +178,32 @@ function MP.UTILS.parse_modlist(mod_entries)
 	return mods
 end
 
+-- "0.4.0~pre1-DEV" -> "0.4.0". nil if no leading numeric version.
+function MP.UTILS.version_prefix(version)
+	if type(version) ~= "string" then return nil end
+	return version:match("^(%d+%.%d+%.%d+)") or version:match("^(%d+%.%d+)")
+end
+
+-- Reads from hash_str, not the parsed Mods table: parse_modlist splits on the last dash
+-- and would mangle versions that contain dashes (e.g. the -DEV suffix).
+function MP.UTILS.player_mod_version(player, mod_name)
+	if not player or not player.hash_str then return nil end
+	return (";" .. player.hash_str):match(";" .. mod_name .. "%-([^;]+)")
+end
+
+function MP.UTILS.mp_version_mismatch()
+	local other = MP.LOBBY.is_host and MP.LOBBY.guest or MP.LOBBY.host
+	local their_version = other and MP.UTILS.player_mod_version(other, "Multiplayer")
+	if not their_version then return false end
+	local our_version = SMODS.Mods["Multiplayer"].version
+	local our_prefix = MP.UTILS.version_prefix(our_version)
+	local their_prefix = MP.UTILS.version_prefix(their_version)
+	if our_prefix and their_prefix and our_prefix ~= their_prefix then
+		return true, our_version, their_version
+	end
+	return false
+end
+
 function MP.UTILS.get_banned_mods(mods)
 	local banned_mods = {}
 	if not mods then return banned_mods end

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -1260,6 +1260,7 @@ return {
 			k_set_name = "Set your username in the main menu! (Mods > Multiplayer > Config)",
 			k_mod_hash_warning = "Players have different mods or mod versions! This can cause problems!",
 			k_steamodded_warning = "Players have different versions of Steamodded installed. This may cause the seeds to differ.",
+			k_mp_version_warning = "Players are on different Multiplayer versions! Seeds and jokers will desync - update so you both match.",
 			k_warning_unlock_profile = "The profile you are playing on is not fully unlocked. If this is a ranked/tournament game, please create a new profile and hit unlock all in the profile settings",
 			k_warning_nemesis_unlock = "Your opponent is playing on a profile that is not fully unlocked. Please instruct them to create a new profile and hit unlock all in the profile settings",
 			k_warning_no_order = "One player has The Order integration enabled while the other does not. This will cause the seeds to differ.",

--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -213,9 +213,8 @@ local function action_lobbyInfo(p)
 
 	local mismatch, our_version, their_version = MP.UTILS.mp_version_mismatch()
 	if mismatch then
-		MP._version_mismatch = { our = our_version, their = their_version }
+		MP.UI.show_version_mismatch_warning(our_version, their_version)
 	else
-		MP._version_mismatch = nil
 		MP._version_mismatch_shown = false
 	end
 end

--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -213,8 +213,9 @@ local function action_lobbyInfo(p)
 
 	local mismatch, our_version, their_version = MP.UTILS.mp_version_mismatch()
 	if mismatch then
-		MP.UI.show_version_mismatch_warning(our_version, their_version)
+		MP._version_mismatch = { our = our_version, their = their_version }
 	else
+		MP._version_mismatch = nil
 		MP._version_mismatch_shown = false
 	end
 end

--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -215,6 +215,7 @@ local function action_lobbyInfo(p)
 	if mismatch then
 		MP.UI.show_version_mismatch_warning(our_version, their_version)
 	else
+		MP._version_mismatch = nil
 		MP._version_mismatch_shown = false
 	end
 end

--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -210,6 +210,13 @@ local function action_lobbyInfo(p)
 	if MP.LOBBY.is_host then MP.ACTIONS.lobby_options() end
 
 	if G.STAGE == G.STAGES.MAIN_MENU then MP.ACTIONS.update_player_usernames() end
+
+	local mismatch, our_version, their_version = MP.UTILS.mp_version_mismatch()
+	if mismatch then
+		MP.UI.show_version_mismatch_warning(our_version, their_version)
+	else
+		MP._version_mismatch_shown = false
+	end
 end
 
 local function action_error(p)

--- a/ui/lobby/lobby.lua
+++ b/ui/lobby/lobby.lua
@@ -393,7 +393,6 @@ function G.FUNCS.lobby_leave(e)
 			MP.ACTIONS.leave_lobby()
 			MP.UI.update_connection_status()
 			MP.MODIFIERS = {}
-			MP._version_mismatch = nil
 			MP._version_mismatch_shown = false
 			G.STATE = G.STATES.MENU
 		end)
@@ -402,7 +401,6 @@ function G.FUNCS.lobby_leave(e)
 		MP.ACTIONS.leave_lobby()
 		MP.UI.update_connection_status()
 		MP.MODIFIERS = {}
-		MP._version_mismatch = nil
 		MP._version_mismatch_shown = false
 		G.STATE = G.STATES.MENU
 	end

--- a/ui/lobby/lobby.lua
+++ b/ui/lobby/lobby.lua
@@ -393,6 +393,7 @@ function G.FUNCS.lobby_leave(e)
 			MP.ACTIONS.leave_lobby()
 			MP.UI.update_connection_status()
 			MP.MODIFIERS = {}
+			MP._version_mismatch = nil
 			MP._version_mismatch_shown = false
 			G.STATE = G.STATES.MENU
 		end)
@@ -401,6 +402,7 @@ function G.FUNCS.lobby_leave(e)
 		MP.ACTIONS.leave_lobby()
 		MP.UI.update_connection_status()
 		MP.MODIFIERS = {}
+		MP._version_mismatch = nil
 		MP._version_mismatch_shown = false
 		G.STATE = G.STATES.MENU
 	end

--- a/ui/lobby/lobby.lua
+++ b/ui/lobby/lobby.lua
@@ -393,6 +393,7 @@ function G.FUNCS.lobby_leave(e)
 			MP.ACTIONS.leave_lobby()
 			MP.UI.update_connection_status()
 			MP.MODIFIERS = {}
+			MP._version_mismatch_shown = false
 			G.STATE = G.STATES.MENU
 		end)
 	else
@@ -400,6 +401,7 @@ function G.FUNCS.lobby_leave(e)
 		MP.ACTIONS.leave_lobby()
 		MP.UI.update_connection_status()
 		MP.MODIFIERS = {}
+		MP._version_mismatch_shown = false
 		G.STATE = G.STATES.MENU
 	end
 end

--- a/ui/lobby/start_ready_button.lua
+++ b/ui/lobby/start_ready_button.lua
@@ -61,6 +61,14 @@ local function get_warnings()
 		end
 	end
 
+	if MP.UTILS.mp_version_mismatch() then
+		table.insert(warnings, {
+			localize("k_mp_version_warning"),
+			G.C.RED,
+			0.4,
+		})
+	end
+
 	local host_banned_mods = MP.LOBBY.host
 			and MP.LOBBY.host.config
 			and MP.UTILS.get_banned_mods(MP.LOBBY.host.config.Mods)

--- a/ui/lobby/version_mismatch_warning.lua
+++ b/ui/lobby/version_mismatch_warning.lua
@@ -4,7 +4,6 @@ end
 
 function MP.UI.show_version_mismatch_warning(our_version, their_version)
 	if MP._version_mismatch_shown then return end
-	if G.STAGE ~= G.STAGES.MAIN_MENU then return end
 
 	MP._version_mismatch_shown = true
 
@@ -77,4 +76,15 @@ function MP.UI.show_version_mismatch_warning(our_version, their_version)
 			},
 		}),
 	})
+end
+
+-- Detection happens in action_lobbyInfo, but the guest's lobbyInfo can land mid
+-- join->menu transition, so show from the update loop once the lobby stage is ready.
+local _vmw_update = Game.update
+function Game:update(dt)
+	_vmw_update(self, dt)
+	local m = MP._version_mismatch
+	if m and not MP._version_mismatch_shown and MP.LOBBY.code and G.STAGE == G.STAGES.MAIN_MENU then
+		MP.UI.show_version_mismatch_warning(m.our, m.their)
+	end
 end

--- a/ui/lobby/version_mismatch_warning.lua
+++ b/ui/lobby/version_mismatch_warning.lua
@@ -4,6 +4,7 @@ end
 
 function MP.UI.show_version_mismatch_warning(our_version, their_version)
 	if MP._version_mismatch_shown then return end
+	if G.STAGE ~= G.STAGES.MAIN_MENU then return end
 
 	MP._version_mismatch_shown = true
 
@@ -76,15 +77,4 @@ function MP.UI.show_version_mismatch_warning(our_version, their_version)
 			},
 		}),
 	})
-end
-
--- Detection happens in action_lobbyInfo, but the guest's lobbyInfo can land mid
--- join->menu transition, so show from the update loop once the lobby stage is ready.
-local _vmw_update = Game.update
-function Game:update(dt)
-	_vmw_update(self, dt)
-	local m = MP._version_mismatch
-	if m and not MP._version_mismatch_shown and MP.LOBBY.code and G.STAGE == G.STAGES.MAIN_MENU then
-		MP.UI.show_version_mismatch_warning(m.our, m.their)
-	end
 end

--- a/ui/lobby/version_mismatch_warning.lua
+++ b/ui/lobby/version_mismatch_warning.lua
@@ -1,0 +1,80 @@
+function G.FUNCS.mp_open_update_docs(e)
+	love.system.openURL("https://balatromp.com/docs/getting-started/installation")
+end
+
+function MP.UI.show_version_mismatch_warning(our_version, their_version)
+	if MP._version_mismatch_shown then return end
+	if G.STAGE ~= G.STAGES.MAIN_MENU then return end
+
+	MP._version_mismatch_shown = true
+
+	G.FUNCS.overlay_menu({
+		definition = create_UIBox_generic_options({
+			no_back = true,
+			contents = {
+				MP.UI.UTILS.create_column({ align = "cm", padding = 0.15 }, {
+					MP.UI.UTILS.create_row({ align = "cm", padding = 0.1 }, {
+						MP.UI.UTILS.create_text_node("VERSION MISMATCH", {
+							scale = 0.8,
+							colour = G.C.RED,
+						}),
+					}),
+					MP.UI.UTILS.create_row({ align = "cm", padding = 0.04 }, {
+						MP.UI.UTILS.create_text_node("You and your opponent are on different", {
+							scale = 0.4,
+							colour = G.C.UI.TEXT_LIGHT,
+						}),
+					}),
+					MP.UI.UTILS.create_row({ align = "cm", padding = 0.04 }, {
+						MP.UI.UTILS.create_text_node("Multiplayer versions. Seeds, shops and", {
+							scale = 0.4,
+							colour = G.C.UI.TEXT_LIGHT,
+						}),
+					}),
+					MP.UI.UTILS.create_row({ align = "cm", padding = 0.04 }, {
+						MP.UI.UTILS.create_text_node("jokers will desync - matches may break.", {
+							scale = 0.4,
+							colour = G.C.UI.TEXT_LIGHT,
+						}),
+					}),
+					MP.UI.UTILS.create_row({ align = "cm", padding = 0.12 }, {
+						MP.UI.UTILS.create_text_node("You: " .. tostring(our_version), {
+							scale = 0.45,
+							colour = G.C.BLUE,
+						}),
+						MP.UI.UTILS.create_blank(0.4, 0.1),
+						MP.UI.UTILS.create_text_node("Them: " .. tostring(their_version), {
+							scale = 0.45,
+							colour = G.C.ORANGE,
+						}),
+					}),
+					MP.UI.UTILS.create_row({ align = "cm", padding = 0.04 }, {
+						MP.UI.UTILS.create_text_node("Update so you both match before playing.", {
+							scale = 0.4,
+							colour = G.C.UI.TEXT_LIGHT,
+						}),
+					}),
+					MP.UI.UTILS.create_row({ align = "cm", padding = 0.15 }, {
+						UIBox_button({
+							label = { "How to update" },
+							button = "mp_open_update_docs",
+							colour = HEX("72A5F2"),
+							minw = 4.2,
+							scale = 0.5,
+							col = true,
+						}),
+						MP.UI.UTILS.create_blank(0.25, 0.1),
+						UIBox_button({
+							label = { "Continue anyway" },
+							button = "exit_overlay_menu",
+							colour = G.C.RED,
+							minw = 3.4,
+							scale = 0.5,
+							col = true,
+						}),
+					}),
+				}),
+			},
+		}),
+	})
+end

--- a/ui/lobby/version_mismatch_warning.lua
+++ b/ui/lobby/version_mismatch_warning.lua
@@ -2,12 +2,7 @@ function G.FUNCS.mp_open_update_docs(e)
 	love.system.openURL("https://balatromp.com/docs/getting-started/installation")
 end
 
-function MP.UI.show_version_mismatch_warning(our_version, their_version)
-	if MP._version_mismatch_shown then return end
-	if G.STAGE ~= G.STAGES.MAIN_MENU then return end
-
-	MP._version_mismatch_shown = true
-
+local function build_version_mismatch_modal(our_version, their_version)
 	G.FUNCS.overlay_menu({
 		definition = create_UIBox_generic_options({
 			no_back = true,
@@ -77,4 +72,29 @@ function MP.UI.show_version_mismatch_warning(our_version, their_version)
 			},
 		}),
 	})
+end
+
+-- Arm once per mismatch, then show only after the lobby is visually settled. The
+-- guest's mismatch is detected mid join->menu transition, where go_to_menu's screenwipe
+-- would tear an overlay back down. The deferred event waits out the wipe and any
+-- competing overlay (re-runs while it returns false) before building the modal.
+function MP.UI.show_version_mismatch_warning(our_version, their_version)
+	if MP._version_mismatch_shown then return end
+	MP._version_mismatch_shown = true
+	MP._version_mismatch = { our = our_version, their = their_version }
+
+	G.E_MANAGER:add_event(Event({
+		trigger = "after",
+		delay = 0.3,
+		blocking = false,
+		blockable = false,
+		no_delete = true,
+		func = function()
+			if G.screenwipe or G.OVERLAY_MENU then return false end
+			if G.STAGE ~= G.STAGES.MAIN_MENU or not MP.LOBBY.code then return true end
+			local m = MP._version_mismatch
+			if m then build_version_mismatch_modal(m.our, m.their) end
+			return true
+		end,
+	}))
 end


### PR DESCRIPTION
0.4.0 ships a required SMODS bump, and nothing stopped two people on different versions from sitting down to a quietly-desyncing match — so now they get a soft lobby warning and a modal that's hard to miss.

The modal works on both seats, eventually: the guest's copy kept getting swallowed by the join transition until we taught the event to outlive the screenwipe. Only checks the X.Y.Z prefix, so dev builds don't cry wolf.