### PR TITLE
build(release): add release.sh and .env server overrides for playtest builds

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
 # Experimental flags — copy to .env and edit as needed
 show_sandbox_collection=false
 alt_stakes=false
+
+# Server overrides (take precedence over Multiplayer.jkr / config.lua)
+# server_url=balatro.virtualized.dev
+# server_port=8788

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .DS_Store
 .env
 .claude/
+dist/
 CLAUDE.local.md
 replays/*
 !replays/.gitkeep

--- a/Multiplayer.json
+++ b/Multiplayer.json
@@ -12,7 +12,7 @@
   "priority": 10000000,
   "badge_colour": "AC3232",
   "badge_text_colour": "FFFFFF",
-  "version": "0.4.0~pre1-DEV",
+  "version": "0.4.0~pre2-DEV",
   "dependencies": [
     "Steamodded (>=1.0.0~BETA-1221a)",
     "Lovely (>=0.8)",

--- a/Multiplayer.json
+++ b/Multiplayer.json
@@ -12,7 +12,7 @@
   "priority": 10000000,
   "badge_colour": "AC3232",
   "badge_text_colour": "FFFFFF",
-  "version": "0.4.0~pre2-DEV",
+  "version": "0.4.0~pre3-DEV",
   "dependencies": [
     "Steamodded (>=1.0.0~BETA-1221a)",
     "Lovely (>=0.8)",

--- a/config.lua
+++ b/config.lua
@@ -2,7 +2,7 @@ return {
 	["username"] = "Guest",
 	["blind_col"] = 1,
 	["server_url"] = "balatro.virtualized.dev",
-	["server_port"] = 8788,
+	["server_port"] = 8799,
 	["logging"] = false,
 	["misprint_display"] = true,
 	["integrations"] = {

--- a/config.lua
+++ b/config.lua
@@ -2,7 +2,7 @@ return {
 	["username"] = "Guest",
 	["blind_col"] = 1,
 	["server_url"] = "balatro.virtualized.dev",
-	["server_port"] = 8799,
+	["server_port"] = 8788,
 	["logging"] = false,
 	["misprint_display"] = true,
 	["integrations"] = {

--- a/core.lua
+++ b/core.lua
@@ -68,7 +68,8 @@ MP.EXPERIMENTAL = {
 	mem_debug = true,
 }
 
--- Override experimental flags from .env file if present
+-- Override experimental flags and server config from .env file if present
+MP.ENV = {}
 local env_path = MP.path .. "/.env"
 local env_info = NFS.getInfo(env_path)
 if env_info then
@@ -78,17 +79,20 @@ if env_info then
 			line = line:match("^%s*(.-)%s*$") -- trim
 			if line ~= "" and not line:match("^#") then
 				local key, val = line:match("^([%w_]+)%s*=%s*(.+)$")
-				if key and MP.EXPERIMENTAL[key] ~= nil then
+				if key then
 					if val == "true" then
 						val = true
 					elseif val == "false" then
 						val = false
 					end
-					MP.EXPERIMENTAL[key] = val
+					MP.ENV[key] = val
+					if MP.EXPERIMENTAL[key] ~= nil then
+						MP.EXPERIMENTAL[key] = val
+					end
 				end
 			end
 		end
-		sendDebugMessage("Loaded .env overrides for MP.EXPERIMENTAL", "MULTIPLAYER")
+		sendDebugMessage("Loaded .env overrides", "MULTIPLAYER")
 	end
 end
 
@@ -317,5 +321,11 @@ MP.load_mp_dir("objects/challenges")
 
 local SOCKET = MP.load_mp_file("networking/socket.lua")
 MP.NETWORKING_THREAD = love.thread.newThread(SOCKET)
-MP.NETWORKING_THREAD:start(SMODS.Mods["Multiplayer"].config.server_url, SMODS.Mods["Multiplayer"].config.server_port)
+local server_url = MP.ENV.server_url or SMODS.Mods["Multiplayer"].config.server_url
+local server_port = tonumber(MP.ENV.server_port) or SMODS.Mods["Multiplayer"].config.server_port
+sendInfoMessage(
+	string.format("Connecting to %s:%s", tostring(server_url), tostring(server_port)),
+	"MULTIPLAYER"
+)
+MP.NETWORKING_THREAD:start(server_url, server_port)
 MP.ACTIONS.connect()

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -8,10 +8,10 @@
 #               keeps the "-DEV" version (which triggers the in-game dev warning).
 #
 #   --release   Shippable build. Source is still the WORKING TREE for now
-#               (see TODO below to switch to a clean git tag/ref), but:
+#               (TODO: switch to a clean git tag/ref + GitHub runner), but:
 #                 - .env is NOT shipped (build falls back to config.lua)
 #                 - version is auto-stripped to a clean release string
-#                   (drops ~preN and -DEV, so no dev-warning overlay)
+#                   (drops ~preN and -DEV)
 #                 - config.lua server port is forced to production
 #                 - core.lua debug defaults (mem_debug) are turned off
 #
@@ -24,7 +24,7 @@ set -euo pipefail
 PROD_SERVER_URL="balatro.virtualized.dev"
 PROD_SERVER_PORT=8788
 
-# --- mode (required, no default — defaulting would risk leaking your .env) ---
+# --- mode (required) ---
 MODE="${1:-}"
 case "$MODE" in
   --dev)     MODE=dev ;;
@@ -41,7 +41,7 @@ cd "$ROOT"
 # Portable in-place edit (BSD/macOS + GNU sed differ; perl is consistent).
 inplace() { perl -0pi -e "$1" "$2"; }
 
-# --- version (from manifest), with release sanitization ---------------------
+# --- version (from manifest) ---------------------
 VERSION="$(grep -m1 '"version"' Multiplayer.json \
   | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')"
 
@@ -72,8 +72,10 @@ mkdir -p "$STAGE"
 #   git archive --format=tar <tag> | ( cd "$STAGE" && tar -xf - )
 # then skip the rsync below. For now both modes use the working tree.
 #
-# -a archive. In --dev we also pass -L to follow symlinks (turns the .env
-# symlink into its real contents); --release excludes .env entirely instead.
+# -a archive. In --dev we also pass -L to follow symlinks
+# to symlink into its real contents)
+# as some maintainers use symlinks for their .env.
+# --release excludes .env entirely instead.
 RSYNC_FLAGS=(-a)
 ENV_EXCLUDE=()
 if [ "$MODE" = dev ]; then
@@ -134,8 +136,7 @@ fi
 # --- zip it -----------------------------------------------------------------
 # Zip from INSIDE the stage so the mod files land at the archive root (no outer
 # "Multiplayer-vX/" wrapper). BMM and balatromp.com expect Multiplayer.json at
-# the zip root — see .github/RELEASE_CHECKLIST.md ("recompress from the files
-# instead of the outer folder").
+# the zip root — see .github/RELEASE_CHECKLIST.md
 ( cd "$STAGE" && zip -rqX "../${NAME}.zip" . )
 
 echo "==> folder: ${STAGE}"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -15,8 +15,10 @@
 #                 - config.lua server port is forced to production
 #                 - core.lua debug defaults (mem_debug) are turned off
 #
-# Output: dist/Multiplayer-v<version>/      (clean unzipped folder)
-#         dist/Multiplayer-v<version>.zip   (zipped, ready to ship)
+# Output: dist/Multiplayer-v<version>/      (clean unzipped folder, both modes)
+#         dist/Multiplayer-v<version>.zip   (--dev: versioned playtest zip)
+#         dist/BalatroMultiplayer.zip       (--release: literal name BMM and
+#                                            balatromp.com require)
 #
 set -euo pipefail
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -58,59 +58,68 @@ fi
 SAFE_VERSION="$(printf '%s' "$VERSION" | tr -c 'A-Za-z0-9._-' '_')"
 NAME="Multiplayer-v${SAFE_VERSION}"
 
+# Release artifacts MUST be named exactly "BalatroMultiplayer.zip" — BMM and
+# balatromp.com look up that literal filename for every release (see
+# .github/RELEASE_CHECKLIST.md). Dev builds stay versioned so playtest zips
+# don't clobber each other.
+if [ "$MODE" = release ]; then
+  ZIP_NAME="BalatroMultiplayer"
+else
+  ZIP_NAME="$NAME"
+fi
+
 DIST="${ROOT}/dist"
 STAGE="${DIST}/${NAME}"
-ZIP="${DIST}/${NAME}.zip"
+ZIP="${DIST}/${ZIP_NAME}.zip"
 
 echo "==> building ${NAME}  (mode: ${MODE}, version: ${VERSION})"
 
 rm -rf "$STAGE" "$ZIP"
 mkdir -p "$STAGE"
 
-# --- copy working tree, strip noise -----------------------------------------
-# TODO(release): build from a clean git ref instead of the working tree, e.g.
-#   git archive --format=tar <tag> | ( cd "$STAGE" && tar -xf - )
-# then skip the rsync below. For now both modes use the working tree.
+# --- enumerate the files that should ship -----------------------------------
+# The file list comes from git, not from a raw filesystem walk, so the build
+# only ever contains things that actually belong to the repo
+
+# local dev folders, editor/tooling junk, scratch files, 
+# and anything matched by .gitignore are excluded
 #
-# -a archive. In --dev we also pass -L to follow symlinks
-# to symlink into its real contents)
-# as some maintainers use symlinks for their .env.
-# --release excludes .env entirely instead.
+#   --dev:     tracked files + new (untracked, non-ignored) files
+#   --release: tracked files only — a clean, repo-faithful set
+#
+# -a archive. In --dev we also pass -L to follow symlinks (some maintainers
+# symlink their .env to its real contents); --release omits .env entirely.
 RSYNC_FLAGS=(-a)
-ENV_EXCLUDE=()
+GIT_LS=(git ls-files -z)
 if [ "$MODE" = dev ]; then
   RSYNC_FLAGS+=(-L)
+  GIT_LS+=(--cached --others --exclude-standard)
 else
-  ENV_EXCLUDE+=(--exclude='/.env')
+  GIT_LS+=(--cached)
 fi
 
-rsync "${RSYNC_FLAGS[@]}" \
-  ${ENV_EXCLUDE[@]+"${ENV_EXCLUDE[@]}"} \
-  --exclude='/dist/' \
-  --exclude='.git' \
-  --exclude='/.github/' \
-  --exclude='.gitignore' \
-  --exclude='.gitattributes' \
-  --exclude='.DS_Store' \
-  --exclude='/.context/' \
-  --exclude='/.claude/' \
-  --exclude='.vscode/' \
-  --exclude='.idea/' \
-  --exclude='.vs/' \
-  --exclude='.luarc.json' \
-  --exclude='.lovelyignore' \
-  --exclude='/agents.md' \
-  --exclude='CLAUDE.md' \
-  --exclude='CLAUDE.local.md' \
-  --exclude='/CONTRIBUTING.md' \
-  --exclude='stylua.toml' \
-  --exclude='/tests/' \
-  --exclude='/scripts/' \
-  ./ "$STAGE/"
+# Build the NUL-delimited file list, then pipe it straight into rsync 
+# .env is gitignored on purpose (git never lists it), so
+# append it by hand for dev builds 
+{
+  "${GIT_LS[@]}" -- \
+    ':(exclude).github' \
+    ':(exclude).gitignore' \
+    ':(exclude)stylua.toml' \
+    ':(exclude)agents.md' \
+    ':(exclude)CONTRIBUTING.md' \
+    ':(exclude)tests' \
+    ':(exclude)scripts' \
+    ':(exclude).claude' 
+  if [ "$MODE" = dev ] && [ -e .env ]; then
+    printf '%s\0' .env
+  fi
+} | rsync "${RSYNC_FLAGS[@]}" --from0 --files-from=- ./ "$STAGE/"
 
+# we love macOS here
 find "$STAGE" -name '.DS_Store' -delete
 
-# --- release-only: sanitize the staged copy ---------------------------------
+# --- sanitize the release copy ---------------------------------
 if [ "$MODE" = release ]; then
   # Clean version into the shipped manifest (no ~preN / -DEV -> no dev warning).
   inplace "s/(\"version\"\\s*:\\s*\")[^\"]+\"/\${1}${VERSION}\"/" "$STAGE/Multiplayer.json"
@@ -134,10 +143,10 @@ else
 fi
 
 # --- zip it -----------------------------------------------------------------
-# Zip from INSIDE the stage so the mod files land at the archive root (no outer
+# from INSIDE the stage so the mod files land at the archive root (no outer
 # "Multiplayer-vX/" wrapper). BMM and balatromp.com expect Multiplayer.json at
 # the zip root — see .github/RELEASE_CHECKLIST.md
-( cd "$STAGE" && zip -rqX "../${NAME}.zip" . )
+( cd "$STAGE" && zip -rqX "../${ZIP_NAME}.zip" . )
 
 echo "==> folder: ${STAGE}"
 echo "==> zip:    ${ZIP}"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# release.sh — build the Multiplayer mod, in one of two modes:
+#
+#   --dev       Playtest/dev build. Source is the WORKING TREE (uncommitted edits
+#               included). Your real .env is baked in so
+#               the build talks to whatever server/port your .env points at and
+#               keeps the "-DEV" version (which triggers the in-game dev warning).
+#
+#   --release   Shippable build. Source is still the WORKING TREE for now
+#               (see TODO below to switch to a clean git tag/ref), but:
+#                 - .env is NOT shipped (build falls back to config.lua)
+#                 - version is auto-stripped to a clean release string
+#                   (drops ~preN and -DEV, so no dev-warning overlay)
+#                 - config.lua server port is forced to production
+#                 - core.lua debug defaults (mem_debug) are turned off
+#
+# Output: dist/Multiplayer-v<version>/      (clean unzipped folder)
+#         dist/Multiplayer-v<version>.zip   (zipped, ready to ship)
+#
+set -euo pipefail
+
+# --- production server (used by --release to sanitize config.lua) ------------
+PROD_SERVER_URL="balatro.virtualized.dev"
+PROD_SERVER_PORT=8788
+
+# --- mode (required, no default — defaulting would risk leaking your .env) ---
+MODE="${1:-}"
+case "$MODE" in
+  --dev)     MODE=dev ;;
+  --release) MODE=release ;;
+  *)
+    echo "usage: $(basename "$0") --dev | --release" >&2
+    exit 2
+    ;;
+esac
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+# Portable in-place edit (BSD/macOS + GNU sed differ; perl is consistent).
+inplace() { perl -0pi -e "$1" "$2"; }
+
+# --- version (from manifest), with release sanitization ---------------------
+VERSION="$(grep -m1 '"version"' Multiplayer.json \
+  | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/')"
+
+if [ "$MODE" = release ]; then
+  # Strip the pre-release/dev tail: "0.4.0~pre2-DEV" -> "0.4.0".
+  VERSION="${VERSION%%~*}"              # drop everything from the first '~'
+  VERSION="${VERSION%-[Dd][Ee][Vv]}"   # drop a trailing '-DEV' if no '~' was present
+  if printf '%s' "$VERSION" | grep -qi 'dev'; then
+    echo "!! refusing to make a release: version still looks like a dev build ('$VERSION')" >&2
+    exit 1
+  fi
+fi
+
+SAFE_VERSION="$(printf '%s' "$VERSION" | tr -c 'A-Za-z0-9._-' '_')"
+NAME="Multiplayer-v${SAFE_VERSION}"
+
+DIST="${ROOT}/dist"
+STAGE="${DIST}/${NAME}"
+ZIP="${DIST}/${NAME}.zip"
+
+echo "==> building ${NAME}  (mode: ${MODE}, version: ${VERSION})"
+
+rm -rf "$STAGE" "$ZIP"
+mkdir -p "$STAGE"
+
+# --- copy working tree, strip noise -----------------------------------------
+# TODO(release): build from a clean git ref instead of the working tree, e.g.
+#   git archive --format=tar <tag> | ( cd "$STAGE" && tar -xf - )
+# then skip the rsync below. For now both modes use the working tree.
+#
+# -a archive. In --dev we also pass -L to follow symlinks (turns the .env
+# symlink into its real contents); --release excludes .env entirely instead.
+RSYNC_FLAGS=(-a)
+ENV_EXCLUDE=()
+if [ "$MODE" = dev ]; then
+  RSYNC_FLAGS+=(-L)
+else
+  ENV_EXCLUDE+=(--exclude='/.env')
+fi
+
+rsync "${RSYNC_FLAGS[@]}" \
+  ${ENV_EXCLUDE[@]+"${ENV_EXCLUDE[@]}"} \
+  --exclude='/dist/' \
+  --exclude='.git' \
+  --exclude='/.github/' \
+  --exclude='.gitignore' \
+  --exclude='.gitattributes' \
+  --exclude='.DS_Store' \
+  --exclude='/.context/' \
+  --exclude='/.claude/' \
+  --exclude='.vscode/' \
+  --exclude='.idea/' \
+  --exclude='.vs/' \
+  --exclude='.luarc.json' \
+  --exclude='.lovelyignore' \
+  --exclude='/agents.md' \
+  --exclude='CLAUDE.md' \
+  --exclude='CLAUDE.local.md' \
+  --exclude='/CONTRIBUTING.md' \
+  --exclude='stylua.toml' \
+  --exclude='/tests/' \
+  --exclude='/scripts/' \
+  ./ "$STAGE/"
+
+find "$STAGE" -name '.DS_Store' -delete
+
+# --- release-only: sanitize the staged copy ---------------------------------
+if [ "$MODE" = release ]; then
+  # Clean version into the shipped manifest (no ~preN / -DEV -> no dev warning).
+  inplace "s/(\"version\"\\s*:\\s*\")[^\"]+\"/\${1}${VERSION}\"/" "$STAGE/Multiplayer.json"
+  # Point config.lua at the production server (working tree may hold a dev port).
+  inplace "s/(\\[\"server_url\"\\]\\s*=\\s*\")[^\"]*\"/\${1}${PROD_SERVER_URL}\"/" "$STAGE/config.lua"
+  inplace "s/(\\[\"server_port\"\\]\\s*=\\s*)\\d+/\${1}${PROD_SERVER_PORT}/"       "$STAGE/config.lua"
+fi
+
+# --- sanity: make sure the bits that MUST (and must NOT) ship are present ----
+for required in Multiplayer.json core.lua; do
+  if [ ! -e "${STAGE}/${required}" ]; then
+    echo "!! WARNING: expected '${required}' missing from build" >&2
+  fi
+done
+
+if [ "$MODE" = dev ]; then
+  [ -e "${STAGE}/.env" ] || echo "!! WARNING: dev build but '.env' missing" >&2
+else
+  [ -e "${STAGE}/.env" ] && echo "!! WARNING: release build is shipping a '.env' — it should not" >&2
+  [ -e "${STAGE}/.env.example" ] || echo "!! WARNING: release build missing '.env.example'" >&2
+fi
+
+# --- zip it -----------------------------------------------------------------
+( cd "$DIST" && zip -rqX "${NAME}.zip" "$NAME" )
+
+echo "==> folder: ${STAGE}"
+echo "==> zip:    ${ZIP}"
+echo "==> done."

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -132,7 +132,11 @@ else
 fi
 
 # --- zip it -----------------------------------------------------------------
-( cd "$DIST" && zip -rqX "${NAME}.zip" "$NAME" )
+# Zip from INSIDE the stage so the mod files land at the archive root (no outer
+# "Multiplayer-vX/" wrapper). BMM and balatromp.com expect Multiplayer.json at
+# the zip root — see .github/RELEASE_CHECKLIST.md ("recompress from the files
+# instead of the outer folder").
+( cd "$STAGE" && zip -rqX "../${NAME}.zip" . )
 
 echo "==> folder: ${STAGE}"
 echo "==> zip:    ${ZIP}"


### PR DESCRIPTION
Two playtest builds from one working tree: `--dev` bakes in your `.env` and keeps the `-DEV` warning; `--release` drops `.env`, strips `~preN`/`-DEV`, and pins config to production.
`.env` now overrides `server_url`/`server_port` (loaded into `MP.ENV`); the alternative was asking playtesters to hand-edit the config buried inside their `Multiplayer.jkr` in some other folder.
Falls back to `config.lua` when unset, logs the chosen endpoint on connect, and bumps the manifest to `0.4.0~pre2-DEV`.
Builds still come from the working tree, uncommitted edits included — clean-ref builds are a TODO in the script.