### PR TITLE
fix(jokers): pay Bean and Seltzer the dollar we owed them

### DIFF
--- a/objects/jokers/standard/seltzer.lua
+++ b/objects/jokers/standard/seltzer.lua
@@ -6,7 +6,7 @@ SMODS.Joker({
 	blueprint_compat = true,
 	eternal_compat = false,
 	rarity = 2,
-	cost = 5,
+	cost = 6,
 	pos = { x = 3, y = 15 },
 	config = { extra = { hands_left = 8 }, mp_balanced = true },
 	loc_vars = function(self, info_queue, card)

--- a/objects/jokers/standard/turtle_bean.lua
+++ b/objects/jokers/standard/turtle_bean.lua
@@ -6,7 +6,7 @@ SMODS.Joker({
 	blueprint_compat = false,
 	eternal_compat = false,
 	rarity = 2,
-	cost = 5,
+	cost = 6,
 	pos = { x = 4, y = 13 },
 	config = { extra = { h_size = 4, h_mod = 1 }, mp_balanced = true },
 	loc_vars = function(self, info_queue, card)


### PR DESCRIPTION
Two reworks were quietly shortchanging players a buck on sell value — Bean and Seltzer both shipped at `cost = 5` instead of vanilla's `6`. Reparations issued; the soda is once again worth what the soda is worth.

- Turtle Bean: `cost` 5 → 6 (sell $2 → $3)
- Seltzer: `cost` 5 → 6 (sell $2 → $3)