### PR TITLE
fix(lobby): reliable version-mismatch modal + Steamodded check

### DIFF
--- a/lib/matchmaking.lua
+++ b/lib/matchmaking.lua
@@ -212,6 +212,39 @@ function MP.UTILS.mp_version_mismatch()
 	return false
 end
 
+-- Multiplayer compares on the X.Y.Z prefix (clean semver); Steamodded on the full string
+-- (its ~BETA-<build> suffix makes any difference worth flagging).
+local VERSION_CHECKS = {
+	{ name = "Multiplayer", prefix = true },
+	{ name = "Steamodded", prefix = false },
+}
+
+-- Returns { mod, our, their } for each checked mod whose version differs from the opponent's.
+function MP.UTILS.version_mismatches()
+	local other = MP.LOBBY.is_host and MP.LOBBY.guest or MP.LOBBY.host
+	if not other then return {} end
+
+	local results = {}
+	for _, check in ipairs(VERSION_CHECKS) do
+		local their_version = MP.UTILS.player_mod_version(other, check.name)
+		local our_version = SMODS.Mods[check.name] and SMODS.Mods[check.name].version
+		if their_version and our_version then
+			local mismatch
+			if check.prefix then
+				local op = MP.UTILS.version_prefix(our_version)
+				local tp = MP.UTILS.version_prefix(their_version)
+				mismatch = op and tp and op ~= tp
+			else
+				mismatch = our_version ~= their_version
+			end
+			if mismatch then
+				table.insert(results, { mod = check.name, our = our_version, their = their_version })
+			end
+		end
+	end
+	return results
+end
+
 function MP.UTILS.get_banned_mods(mods)
 	local banned_mods = {}
 	if not mods then return banned_mods end

--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -211,13 +211,8 @@ local function action_lobbyInfo(p)
 
 	if G.STAGE == G.STAGES.MAIN_MENU then MP.ACTIONS.update_player_usernames() end
 
-	local mismatch, our_version, their_version = MP.UTILS.mp_version_mismatch()
-	if mismatch then
-		MP.UI.show_version_mismatch_warning(our_version, their_version)
-	else
-		MP._version_mismatch = nil
-		MP._version_mismatch_shown = false
-	end
+	-- Re-arm the mismatch modal when all mismatches clear (opponent left or was replaced).
+	if #MP.UTILS.version_mismatches() == 0 then MP._version_mismatch_shown = false end
 end
 
 local function action_error(p)

--- a/ui/lobby/lobby.lua
+++ b/ui/lobby/lobby.lua
@@ -410,6 +410,11 @@ function G.FUNCS.lobby_start_game(e)
 end
 
 function G.FUNCS.lobby_ready_up(e)
+	-- On the first ready-up with a version mismatch, show the modal and bail without readying;
+	-- the guest must dismiss and press Ready again. Keeps the host's Start (gated on
+	-- ready_to_start) disabled until the mismatch is acknowledged.
+	if not MP.LOBBY.ready_to_start and MP.UI.show_version_mismatch_if_needed() then return end
+
 	MP.LOBBY.ready_to_start = not MP.LOBBY.ready_to_start
 
 	e.config.colour = MP.LOBBY.ready_to_start and G.C.GREEN or G.C.RED
@@ -448,7 +453,6 @@ function G.FUNCS.lobby_leave(e)
 			MP.ACTIONS.leave_lobby()
 			MP.UI.update_connection_status()
 			MP.MODIFIERS = {}
-			MP._version_mismatch = nil
 			MP._version_mismatch_shown = false
 			G.STATE = G.STATES.MENU
 		end)
@@ -457,7 +461,6 @@ function G.FUNCS.lobby_leave(e)
 		MP.ACTIONS.leave_lobby()
 		MP.UI.update_connection_status()
 		MP.MODIFIERS = {}
-		MP._version_mismatch = nil
 		MP._version_mismatch_shown = false
 		G.STATE = G.STATES.MENU
 	end

--- a/ui/lobby/version_mismatch_warning.lua
+++ b/ui/lobby/version_mismatch_warning.lua
@@ -2,99 +2,120 @@ function G.FUNCS.mp_open_update_docs(e)
 	love.system.openURL("https://balatromp.com/docs/getting-started/installation")
 end
 
-local function build_version_mismatch_modal(our_version, their_version)
+local function build_version_mismatch_modal(mismatches)
+	local rows = {
+		MP.UI.UTILS.create_row({ align = "cm", padding = 0.1 }, {
+			MP.UI.UTILS.create_text_node("VERSION MISMATCH", {
+				scale = 0.8,
+				colour = G.C.RED,
+			}),
+		}),
+		MP.UI.UTILS.create_row({ align = "cm", padding = 0.04 }, {
+			MP.UI.UTILS.create_text_node("You and your opponent have mismatched mod", {
+				scale = 0.4,
+				colour = G.C.UI.TEXT_LIGHT,
+			}),
+		}),
+		MP.UI.UTILS.create_row({ align = "cm", padding = 0.04 }, {
+			MP.UI.UTILS.create_text_node("versions. Seeds, shops and jokers will", {
+				scale = 0.4,
+				colour = G.C.UI.TEXT_LIGHT,
+			}),
+		}),
+		MP.UI.UTILS.create_row({ align = "cm", padding = 0.04 }, {
+			MP.UI.UTILS.create_text_node("desync - matches may break.", {
+				scale = 0.4,
+				colour = G.C.UI.TEXT_LIGHT,
+			}),
+		}),
+	}
+
+	-- One row per mismatched mod: "<Mod> -  You: x   Them: y"
+	for _, m in ipairs(mismatches) do
+		table.insert(
+			rows,
+			MP.UI.UTILS.create_row({ align = "cm", padding = 0.1 }, {
+				MP.UI.UTILS.create_text_node(m.mod .. " -", {
+					scale = 0.4,
+					colour = G.C.UI.TEXT_LIGHT,
+				}),
+				MP.UI.UTILS.create_blank(0.2, 0.1),
+				MP.UI.UTILS.create_text_node("You: " .. tostring(m.our), {
+					scale = 0.4,
+					colour = G.C.BLUE,
+				}),
+				MP.UI.UTILS.create_blank(0.3, 0.1),
+				MP.UI.UTILS.create_text_node("Them: " .. tostring(m.their), {
+					scale = 0.4,
+					colour = G.C.ORANGE,
+				}),
+			})
+		)
+	end
+
+	table.insert(
+		rows,
+		MP.UI.UTILS.create_row({ align = "cm", padding = 0.12 }, {
+			MP.UI.UTILS.create_text_node("Update so you both match before playing.", {
+				scale = 0.4,
+				colour = G.C.UI.TEXT_LIGHT,
+			}),
+		})
+	)
+	table.insert(
+		rows,
+		MP.UI.UTILS.create_row({ align = "cm", padding = 0.15 }, {
+			UIBox_button({
+				label = { "How to update" },
+				button = "mp_open_update_docs",
+				colour = HEX("72A5F2"),
+				minw = 4.2,
+				scale = 0.5,
+				col = true,
+			}),
+			MP.UI.UTILS.create_blank(0.25, 0.1),
+			UIBox_button({
+				label = { "Continue anyway" },
+				button = "exit_overlay_menu",
+				colour = G.C.RED,
+				minw = 3.4,
+				scale = 0.5,
+				col = true,
+			}),
+		})
+	)
+
 	G.FUNCS.overlay_menu({
 		definition = create_UIBox_generic_options({
 			no_back = true,
 			contents = {
-				MP.UI.UTILS.create_column({ align = "cm", padding = 0.15 }, {
-					MP.UI.UTILS.create_row({ align = "cm", padding = 0.1 }, {
-						MP.UI.UTILS.create_text_node("VERSION MISMATCH", {
-							scale = 0.8,
-							colour = G.C.RED,
-						}),
-					}),
-					MP.UI.UTILS.create_row({ align = "cm", padding = 0.04 }, {
-						MP.UI.UTILS.create_text_node("You and your opponent are on different", {
-							scale = 0.4,
-							colour = G.C.UI.TEXT_LIGHT,
-						}),
-					}),
-					MP.UI.UTILS.create_row({ align = "cm", padding = 0.04 }, {
-						MP.UI.UTILS.create_text_node("Multiplayer versions. Seeds, shops and", {
-							scale = 0.4,
-							colour = G.C.UI.TEXT_LIGHT,
-						}),
-					}),
-					MP.UI.UTILS.create_row({ align = "cm", padding = 0.04 }, {
-						MP.UI.UTILS.create_text_node("jokers will desync - matches may break.", {
-							scale = 0.4,
-							colour = G.C.UI.TEXT_LIGHT,
-						}),
-					}),
-					MP.UI.UTILS.create_row({ align = "cm", padding = 0.12 }, {
-						MP.UI.UTILS.create_text_node("You: " .. tostring(our_version), {
-							scale = 0.45,
-							colour = G.C.BLUE,
-						}),
-						MP.UI.UTILS.create_blank(0.4, 0.1),
-						MP.UI.UTILS.create_text_node("Them: " .. tostring(their_version), {
-							scale = 0.45,
-							colour = G.C.ORANGE,
-						}),
-					}),
-					MP.UI.UTILS.create_row({ align = "cm", padding = 0.04 }, {
-						MP.UI.UTILS.create_text_node("Update so you both match before playing.", {
-							scale = 0.4,
-							colour = G.C.UI.TEXT_LIGHT,
-						}),
-					}),
-					MP.UI.UTILS.create_row({ align = "cm", padding = 0.15 }, {
-						UIBox_button({
-							label = { "How to update" },
-							button = "mp_open_update_docs",
-							colour = HEX("72A5F2"),
-							minw = 4.2,
-							scale = 0.5,
-							col = true,
-						}),
-						MP.UI.UTILS.create_blank(0.25, 0.1),
-						UIBox_button({
-							label = { "Continue anyway" },
-							button = "exit_overlay_menu",
-							colour = G.C.RED,
-							minw = 3.4,
-							scale = 0.5,
-							col = true,
-						}),
-					}),
-				}),
+				MP.UI.UTILS.create_column({ align = "cm", padding = 0.15 }, rows),
 			},
 		}),
 	})
 end
 
--- Arm once per mismatch, then show only after the lobby is visually settled. The
--- guest's mismatch is detected mid join->menu transition, where go_to_menu's screenwipe
--- would tear an overlay back down. The deferred event waits out the wipe and any
--- competing overlay (re-runs while it returns false) before building the modal.
-function MP.UI.show_version_mismatch_warning(our_version, their_version)
-	if MP._version_mismatch_shown then return end
+-- Show the mismatch modal once per lobby (latched on MP._version_mismatch_shown, re-armed on
+-- lobby leave / when the mismatch clears). Returns true iff it built the modal this call, which
+-- the guest's ready-up uses to intercept the first ready press.
+function MP.UI.show_version_mismatch_if_needed()
+	if MP._version_mismatch_shown then return false end
+	if G.screenwipe or G.OVERLAY_MENU then return false end
+	local mismatches = MP.UTILS.version_mismatches()
+	if #mismatches == 0 then return false end
+	build_version_mismatch_modal(mismatches)
 	MP._version_mismatch_shown = true
-	MP._version_mismatch = { our = our_version, their = their_version }
+	return true
+end
 
-	G.E_MANAGER:add_event(Event({
-		trigger = "after",
-		delay = 0.3,
-		blocking = false,
-		blockable = false,
-		no_delete = true,
-		func = function()
-			if G.screenwipe or G.OVERLAY_MENU then return false end
-			if G.STAGE ~= G.STAGES.MAIN_MENU or not MP.LOBBY.code then return true end
-			local m = MP._version_mismatch
-			if m then build_version_mismatch_modal(m.our, m.their) end
-			return true
-		end,
-	}))
+-- Host trigger: poll while settled in the lobby. (The guest's join transition can't be reliably
+-- detected, so the guest triggers off its ready button instead - see lobby.lua:lobby_ready_up.)
+local mismatch_update_ref = Game.update
+---@diagnostic disable-next-line: duplicate-set-field
+function Game:update(dt)
+	mismatch_update_ref(self, dt)
+
+	if not MP.LOBBY.code or not MP.LOBBY.is_host then return end
+	if G.STAGE ~= G.STAGES.MAIN_MENU then return end
+	MP.UI.show_version_mismatch_if_needed()
 end


### PR DESCRIPTION
The modal raced the guest's join->lobby transition (spawned mid-wipe, torn down before the lobby resolved, then latched as 'shown'). Split the trigger by role: the host polls while settled in the lobby; the guest fires off ready-up, a deterministic in-lobby action. First ready-up with a mismatch shows the modal and bails without readying, so the host's Start (gated on ready_to_start) stays disabled until the guest acknowledges and presses Ready again.

Also extend the check to Steamodded (full-string compare; Multiplayer stays prefix-based) via MP.UTILS.version_mismatches, and show one row per mismatched mod.