### PR TITLE
Add WSOB as tournament ruleset; bump version

### DIFF
--- a/Multiplayer.json
+++ b/Multiplayer.json
@@ -12,7 +12,7 @@
   "priority": 10000000,
   "badge_colour": "AC3232",
   "badge_text_colour": "FFFFFF",
-  "version": "0.4.1~DEV",
+  "version": "0.4.3~DEV",
   "dependencies": [
     "Steamodded (>=1.0.0~BETA-1221a)",
     "Lovely (>=0.8)",

--- a/layers/standard.lua
+++ b/layers/standard.lua
@@ -1,16 +1,26 @@
 MP.Layer("standard", {
-	multiplayer_content = false,
+	multiplayer_content = true,
 	standard = true,
 	banned_silent = {
 		"j_hanging_chad",
+		"j_ticket",
+		"j_selzer",
+		"j_turtle_bean",
 		"j_bloodstone",
+		"c_ouija",
 	},
 	banned_consumables = {
 		"c_justice",
 	},
 	reworked_jokers = {
 		"j_mp_hanging_chad",
+		"j_mp_ticket",
+		"j_mp_seltzer",
+		"j_mp_turtle_bean",
 		"j_mp_bloodstone",
+	},
+	reworked_consumables = {
+		"c_mp_ouija_standard",
 	},
 	reworked_enhancements = {
 		"m_glass",

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -1330,6 +1330,8 @@ return {
 			k_majorleague_description = "Official Major League Balatro ruleset.\n\nVanilla cards with competitive settings:\n- 180 second timer\n- The Order disabled\n- First timeout forgiven\n- Attrition gamemode",
 			k_minorleague = "Minor League",
 			k_minorleague_description = "Official Minor League Balatro ruleset.\n\nVanilla cards with competitive settings:\n- 210 second timer\n- The Order enabled\n- First timeout forgiven\n- Attrition gamemode",
+			k_wsob = "WSOB",
+			k_wsob_description = "World Series of Balatro ruleset.\n\nNear-vanilla card pool with minimal balance changes:\n- Hanging Chad, Bloodstone, and Glass reworked\n- Justice banned\n- No Multiplayer-original content\n\n(See bans and reworks tabs for details)",
 			k_standard_ranked = "Standard Ranked",
 			k_standard_ranked_description = "The official competitive ruleset.\n\nStandard ruleset with locked settings:\n- Attrition gamemode\n- The Order enabled\n- Requires recommended Steamodded version",
 			k_legacy_ranked = "Legacy Ranked",

--- a/objects/enhancements/mp_glass.lua
+++ b/objects/enhancements/mp_glass.lua
@@ -1,5 +1,5 @@
 MP.ReworkCenter("m_glass", {
-	layers = { "standard", "classic" },
+	layers = { "standard", "classic", "wsob" },
 	config = { Xmult = 1.5, extra = 4 },
 })
 

--- a/rulesets/wsob.lua
+++ b/rulesets/wsob.lua
@@ -1,0 +1,33 @@
+-- World Series of Balatro Ruleset
+
+-- Layerless on purpose: WSOB is *not* the standard pool (no MP-original
+-- content, far fewer reworks), so it declares its bans/reworks directly rather
+-- than composing `standard`
+MP.Ruleset({
+	key = "wsob",
+    layers = { "ranked" }, -- let's gate on version though
+	multiplayer_content = false,
+	banned_silent = {
+		"j_hanging_chad",
+		"j_bloodstone",
+	},
+	banned_jokers = {},
+	banned_consumables = {
+		"c_justice",
+	},
+	banned_vouchers = {},
+	banned_enhancements = {},
+	banned_tags = {},
+	banned_blinds = {},
+	reworked_jokers = {
+		"j_mp_hanging_chad",
+		"j_mp_bloodstone",
+	},
+	reworked_consumables = {},
+	reworked_vouchers = {},
+	reworked_enhancements = {
+		"m_glass",
+	},
+	reworked_tags = {},
+	reworked_blinds = {},
+}):inject()

--- a/ui/main_menu/play_button/ruleset_selection.lua
+++ b/ui/main_menu/play_button/ruleset_selection.lua
@@ -60,6 +60,7 @@ local rulesets_tabs = {
 					buttons = {
 						{ button_id = "majorleague_ruleset_button", button_localize_key = "k_majorleague" },
 						{ button_id = "minorleague_ruleset_button", button_localize_key = "k_minorleague" },
+						{ button_id = "wsob_ruleset_button", button_localize_key = "k_wsob" },
 					},
 				},
 				{

--- a/ui/main_menu/play_button/ruleset_selection.lua
+++ b/ui/main_menu/play_button/ruleset_selection.lua
@@ -1,33 +1,3 @@
-local ruleset_buttons_data = {
-	{
-		name = "k_matchmaking",
-		buttons = {
-			{ button_id = "standard_ranked_ruleset_button", button_localize_key = "k_standard_ranked" },
-			{ button_id = "legacy_ranked_ruleset_button", button_localize_key = "k_legacy_ranked" },
-			{ button_id = "smallworld_ruleset_button", button_localize_key = "k_smallworld" },
-			{ button_id = "sandbox_ruleset_button", button_localize_key = "k_sandbox" },
-		},
-	},
-	{
-		name = "k_custom",
-		buttons = {
-			{ button_id = "blitz_ruleset_button", button_localize_key = "k_blitz" },
-			{ button_id = "traditional_ruleset_button", button_localize_key = "k_traditional" },
-			{ button_id = "vanilla_ruleset_button", button_localize_key = "k_vanilla" },
-			{ button_id = "badlatro_ruleset_button", button_localize_key = "k_badlatro" },
-			{ button_id = "speedlatro_ruleset_button", button_localize_key = "k_speedlatro" },
-			{ button_id = "chaos_ruleset_button", button_localize_key = "k_chaos" },
-		},
-	},
-	{
-		name = "k_tournament",
-		buttons = {
-			{ button_id = "majorleague_ruleset_button", button_localize_key = "k_majorleague" },
-			{ button_id = "minorleague_ruleset_button", button_localize_key = "k_minorleague" },
-		},
-	},
-}
-
 local rulesets_tabs = {
 	default = {
 		{


### PR DESCRIPTION
WSOB once became a ruleset by quietly rewriting the standard layer everyone else depends on; this gives it a dedicated ruleset instead and puts standard back exactly as it was.

Wired into the Tournaments tab, gated on the ranked layer, with the Glass rework extended to match.

Also evicted `ruleset_buttons_data`, dead since the #419 tab refactor and fooling no one.

Plus version bump.