### PR TITLE
Pause timer when opponent disconnects

### DIFF
--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -247,6 +247,8 @@ local function action_reconnecting()
 	-- Only show if we were in a lobby and don't already have a countdown running
 	if reconnectToken and lastLobbyCode and not MP.self_reconnect_countdown then
 		MP.LOBBY.connected = false
+		MP.GAME.timer_started = false
+		MP.GAME.nemesis_timer_started = false
 		MP.UI.update_connection_status()
 		sendWarnMessage("Connection lost, attempting to reconnect...", "MULTIPLAYER")
 

--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -145,6 +145,9 @@ local function action_enemyDisconnected(p)
 	local timeout = p.timeout or 60
 	sendWarnMessage("Opponent disconnected, waiting for reconnection...", "MULTIPLAYER")
 
+	MP.GAME.timer_started = false
+	MP.GAME.nemesis_timer_started = false
+
 	MP.enemy_disconnect_countdown = {
 		end_time = love.timer.getTime() + timeout,
 		display = timeout .. "s remaining",

--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -94,6 +94,8 @@ local function action_rejoinedLobby(p)
 	reconnectToken = token
 	lastLobbyCode = code
 	MP.self_reconnect_countdown = nil
+	MP.GAME.timer_started = false
+	MP.GAME.nemesis_timer_started = false
 	MP.ACTIONS.sync_client()
 	MP.ACTIONS.lobby_info()
 	MP.UI.update_connection_status()


### PR DESCRIPTION
## Summary
- Clears both `timer_started` and `nemesis_timer_started` when `enemyDisconnected` is received, stopping the timer for the remaining player
- Timer stays paused after reconnection and must be manually restarted

## Test plan
- [ ] Start a timed match and have one player press the timer button
- [ ] Disconnect the opponent (kill the client)
- [ ] Verify the timer stops ticking for the remaining player
- [ ] Reconnect the opponent and verify the timer does not auto-resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kQrzLNB5kdL18tfVP4gfj

---
_Generated by [Claude Code](https://claude.ai/code/session_016kQrzLNB5kdL18tfVP4gfj)_