### PR TITLE
PvP + hidden score fixes

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -217,6 +217,7 @@ function MP.reset_game_states()
 		end_pvp = false,
 		enemy = {
 			score = MP.INSANE_INT.empty(),
+			real_score = MP.INSANE_INT.empty(),
 			score_text = "0",
 			hands = 4,
 			hands_text = "4",

--- a/lib/ghost_replay.lua
+++ b/lib/ghost_replay.lua
@@ -58,6 +58,7 @@ function MP.GHOST.init_playback(ante)
 		MP.GHOST._hand_idx = 1
 		local score = MP.INSANE_INT.from_string(hands[1].score)
 		MP.GAME.enemy.score = score
+		MP.GAME.enemy.real_score = score
 		MP.GAME.enemy.score_text = MP.INSANE_INT.to_string(score)
 		MP.GAME.enemy.hands = hands[1].hands_left or 0
 		MP.GAME.enemy.info_received = true
@@ -97,6 +98,7 @@ function MP.GHOST.advance_hand()
 		func = function(t) return math.floor(t) end,
 	}))
 
+    MP.GAME.enemy.real_score = score
 	MP.GAME.enemy.hands = entry.hands_left or 0
 	MP.GAME.enemy.info_received = true
 	if MP.UI.juice_up_pvp_hud then MP.UI.juice_up_pvp_hud() end

--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -315,6 +315,7 @@ local function action_start_blind(p)
 	-- Reset the stored opponent score each blind so the first frame after we
 	-- play (which lifts the "???" mask) shows 0, not last blind's stale score.
 	MP.GAME.enemy.score = MP.INSANE_INT.empty()
+	MP.GAME.enemy.real_score = MP.INSANE_INT.empty()
 	MP.GAME.enemy.score_text = "0"
 	-- Re-mask the opponent's hands until the first enemyInfo of the new blind.
 	MP.GAME.enemy.info_received = false
@@ -421,6 +422,7 @@ local function action_enemy_info(p)
 		play_sound("gong", 0.765, 0.4)
 	end
 
+    MP.GAME.enemy.real_score = score
 	MP.GAME.enemy.hands = hands_left
 	MP.GAME.enemy.skips = skips
 	MP.GAME.enemy.lives = lives

--- a/ui/game/timer.lua
+++ b/ui/game/timer.lua
@@ -7,8 +7,9 @@ function MP.UI.cam_timer_opponent()
     if MP.GAME.nemesis_timer_started then return false end
 	if MP.is_pvp_boss() and MP.is_layer_active("pvp_timer") then
 		if G.STATE == G.STATES.ROUND_EVAL or G.STATE == G.STATES.NEW_ROUND then return false end
-		if MP.INSANE_INT.greater_than(MP.GAME.score, MP.GAME.enemy.score) then return true end
-        if MP.INSANE_INT.equal(MP.GAME.score, MP.GAME.enemy.score) then return MP.GAME.pvp_reached_first end
+        if MP.LOBBY.config.hide_score_until_played and not MP.GAME.enemy.info_received then return false end
+		if MP.INSANE_INT.greater_than(MP.GAME.score, MP.GAME.enemy.real_score) then return true end
+        if MP.INSANE_INT.equal(MP.GAME.score, MP.GAME.enemy.real_score) then return MP.GAME.pvp_reached_first end
 		return false
 	end
 	return MP.GAME.ready_blind

--- a/ui/game/timer.lua
+++ b/ui/game/timer.lua
@@ -6,6 +6,7 @@ function MP.UI.cam_timer_opponent()
     if MP.GAME.timer <= 0 then return false end
     if MP.GAME.nemesis_timer_started then return false end
 	if MP.is_pvp_boss() and MP.is_layer_active("pvp_timer") then
+        if MP.GAME.end_pvp then return false end
 		if G.STATE == G.STATES.ROUND_EVAL or G.STATE == G.STATES.NEW_ROUND then return false end
         if MP.LOBBY.config.hide_score_until_played and not MP.GAME.enemy.info_received then return false end
 		if MP.INSANE_INT.greater_than(MP.GAME.score, MP.GAME.enemy.real_score) then return true end


### PR DESCRIPTION
Self-explanatory. Fixed cases when PvP timer was toggling when it shouldn't due to not proper pvp by adding more checks.