### PR TITLE
feat(lobby): block create/join while in matchmaking

### DIFF
--- a/pvp_api/flow.lua
+++ b/pvp_api/flow.lua
@@ -27,6 +27,14 @@ end
 
 function MP.pvp_create_private_lobby(gamemode_key)
 	gamemode_key = gamemode_key or "pvp_standard"
+	-- Block creating a lobby while in matchmaking. The replay re-enters THIS
+	-- function (not MPAPI.create_lobby) so "Leave Queue & Continue" runs the full
+	-- setup -- setup_lobby_mirror + the CONNECTED UI transition below. Replaying
+	-- the API primitive would allocate the lobby server-side but leave the client
+	-- stranded on the menu.
+	if MPAPI.matchmaking.guard_queued(function() return MP.pvp_create_private_lobby(gamemode_key) end) then
+		return
+	end
 	local gm = MPAPI.GameModes[gamemode_key]
 	local max_p = (gm and gm.get_max_players and gm:get_max_players(MPAPI.LobbyType and MPAPI.LobbyType.PRIVATE or "private")) or 2
 	local lobby = MPAPI.create_lobby(MP.id, { max_players = max_p })
@@ -55,6 +63,14 @@ function MP.pvp_join_lobby(code)
 		return
 	end
 	code = tostring(code):gsub("%s", "")
+	-- Block joining while in matchmaking. The replay re-enters THIS function (not
+	-- MPAPI.join_lobby) so "Leave Queue & Continue" runs the full setup --
+	-- setup_lobby_mirror + its CONNECTED UI transition. Replaying the API
+	-- primitive would join server-side (the host sees you) but leave your client
+	-- stranded on the PvP menu.
+	if MPAPI.matchmaking.guard_queued(function() return MP.pvp_join_lobby(code) end) then
+		return
+	end
 	local lobby = MPAPI.join_lobby(MP.id, code)
 	if not lobby then
 		sendWarnMessage("pvp_join_lobby: failed to join " .. tostring(code), "MULTIPLAYER")

--- a/tests/test_lobby_guard_while_queued.lua
+++ b/tests/test_lobby_guard_while_queued.lua
@@ -1,0 +1,124 @@
+--[[
+  Lobby create/join queue-guard test (consumer side).
+
+  Feature: you should not be able to create or join a lobby while in
+  matchmaking. The API exposes MPAPI.matchmaking.guard_queued(replay) (shows a
+  "Leave Queue & Continue" overlay and stashes `replay` to run after leaving);
+  the PvP mod calls it at its lobby entry points.
+
+  Bug this guards against: the guard must replay the CONSUMER entry point
+  (MP.pvp_join_lobby / MP.pvp_create_private_lobby), NOT the API primitive
+  (MPAPI.join_lobby / MPAPI.create_lobby). Those consumer functions call
+  MP.setup_lobby_mirror(lobby) after obtaining the lobby -- that mirror builds
+  the lobby UI and wires the CONNECTED handler that transitions the client into
+  the lobby. Replaying the API primitive alone joins/creates server-side (the
+  other player sees you) but skips setup_lobby_mirror, stranding the client on
+  the PvP main menu. This test pins that: the replay runs setup_lobby_mirror.
+
+  Run from the repo root:
+    luajit tests/test_lobby_guard_while_queued.lua
+]]
+
+-- ── Stubs to load pvp_api/flow.lua ─────────────────────────────────────────
+MP = { id = "pvp" }
+G = { FUNCS = {} }
+function sendWarnMessage(_msg, _cat) end
+
+-- Controllable guard mirroring MPAPI.matchmaking.guard_queued's contract.
+local searching = false
+local stashed = nil
+local overlay_shown = 0
+MPAPI = {
+	id = "pvp",
+	GameModes = {},
+	LobbyEvent = { CONNECTED = "connected" },
+	refresh_current_view = function() end,
+	matchmaking = {
+		guard_queued = function(replay)
+			if searching then
+				stashed = replay
+				overlay_shown = overlay_shown + 1
+				return true
+			end
+			return false
+		end,
+	},
+}
+
+-- Fake lobby + API primitives, with call counters.
+local api_join_calls, api_create_calls, mirror_calls = 0, 0, 0
+local function fake_lobby()
+	return { code = "ABC123", is_host = true, on = function() end }
+end
+MPAPI.join_lobby = function(_mod, _code) api_join_calls = api_join_calls + 1; return fake_lobby() end
+MPAPI.create_lobby = function(_mod, _opts) api_create_calls = api_create_calls + 1; return fake_lobby() end
+
+-- Load the REAL consumer entry points, then stub the mod-side collaborators the
+-- guarded functions call (defined after dofile so they aren't clobbered).
+dofile("pvp_api/flow.lua")
+MP.setup_lobby_mirror = function(_lobby) mirror_calls = mirror_calls + 1 end
+MP.pvp_lobby_metadata = function() return {} end
+
+-- ── Harness ────────────────────────────────────────────────────────────────
+local failures = 0
+local function check(cond, msg)
+	if cond then print("PASS: " .. msg) else failures = failures + 1; print("FAIL: " .. msg) end
+end
+local function reset() searching, stashed, overlay_shown = false, nil, 0; api_join_calls, api_create_calls, mirror_calls = 0, 0, 0 end
+
+-- ── join: blocked while searching ───────────────────────────────────────────
+print()
+print("-- join: blocked while searching --")
+reset(); searching = true
+MP.pvp_join_lobby("ABC123")
+check(api_join_calls == 0, "join: MPAPI.join_lobby NOT called while searching")
+check(mirror_calls == 0, "join: setup_lobby_mirror NOT called while searching")
+check(overlay_shown == 1 and type(stashed) == "function", "join: overlay shown and a replay closure stashed")
+
+-- ── join: Leave Queue & Continue replays the FULL consumer flow ─────────────
+print()
+print("-- join: leave queue & continue runs the full consumer setup --")
+searching = false
+stashed() -- the overlay's replay
+check(api_join_calls == 1, "join replay: MPAPI.join_lobby called after leaving")
+check(mirror_calls == 1, "join replay: setup_lobby_mirror ran (client transitions into the lobby)")
+
+-- ── join: proceeds normally when not searching ──────────────────────────────
+print()
+print("-- join: not searching -> proceeds --")
+reset()
+MP.pvp_join_lobby("ABC123")
+check(api_join_calls == 1 and mirror_calls == 1, "join: joins and mirrors when not searching")
+check(overlay_shown == 0, "join: no overlay when not searching")
+
+-- ── create: blocked while searching, replay runs full setup ─────────────────
+print()
+print("-- create: blocked while searching; replay runs full setup --")
+reset(); searching = true
+MP.pvp_create_private_lobby("pvp_standard")
+check(api_create_calls == 0 and mirror_calls == 0, "create: nothing allocated while searching")
+check(overlay_shown == 1 and type(stashed) == "function", "create: overlay shown and replay stashed")
+searching = false
+stashed()
+check(api_create_calls == 1 and mirror_calls == 1, "create replay: create_lobby + setup_lobby_mirror both ran")
+
+-- ── RED control: replaying the API primitive strands the client ─────────────
+-- Reproduces the original bug -- the stashed replay called MPAPI.join_lobby
+-- directly, so setup_lobby_mirror never ran and the client stayed on the menu.
+print()
+print("-- control: replaying the API primitive skips setup (reproduces the bug) --")
+reset()
+local pre_fix_replay = function() return MPAPI.join_lobby(MP.id, "ABC123") end
+pre_fix_replay()
+check(api_join_calls == 1, "control: server-side join happened (other player sees you)")
+check(mirror_calls == 0, "control: setup_lobby_mirror NEVER ran -- client stranded on the menu")
+
+-- ── Summary ─────────────────────────────────────────────────────────────────
+print()
+if failures == 0 then
+	print("ALL TESTS PASSED")
+	os.exit(0)
+else
+	print(failures .. " TEST(S) FAILED")
+	os.exit(1)
+end


### PR DESCRIPTION
Beta testers could create or join a private lobby while a matchmaking search was active, ending up searching and in a lobby at once. The search kept running server-side with no feedback. This PR blocks both lobby entry points while queued. Two BalatroMultiplayerAPI PRs must merge first (see Depends on).

## The bug
`MP.pvp_create_private_lobby` and `MP.pvp_join_lobby` had no queue check. Nothing stopped a queued player from allocating or joining a lobby mid-search.

## The fix
Both functions now run this guard before touching the API (create's closure re-enters `MP.pvp_create_private_lobby` instead):

```lua
if MPAPI.matchmaking.guard_queued(function() return MP.pvp_join_lobby(code) end) then
	return
end
```

`guard_queued(replay)` lives in the API (Balatro-Multiplayer/BalatroMultiplayerAPI#7). If the player is queued, it shows a "Leave Queue & Continue" overlay, stashes `replay`, and returns true; the caller returns early. If not queued, it returns false and the function proceeds. Clicking the overlay button leaves the queue and runs the stashed replay.

The replay re-enters this mod's own function, not `MPAPI.create_lobby` / `MPAPI.join_lobby`. Only the mod function runs `MP.setup_lobby_mirror` and the CONNECTED handler that moves the client into the lobby. Replaying the API primitive would join or create server-side (the other player sees you) but leave the client stuck on the PvP main menu. That is why the guard lives here and not inside the API primitives.

## How to review
- `pvp_api/flow.lua`: the core change. Two guard blocks, one per entry point. Nothing else changes.
- `tests/test_lobby_guard_while_queued.lua`: new standalone test.

## Tests
Run from the repo root: `luajit tests/test_lobby_guard_while_queued.lua`. No game install needed. Cases:

- Blocked while searching: no API call, no mirror, overlay shown, replay stashed.
- Replay after leaving the queue: `MPAPI.join_lobby` and `MP.setup_lobby_mirror` both run.
- Not searching: join proceeds normally, no overlay.
- Same blocked-then-replay pair for create.
- Red control: a replay that calls the API primitive directly joins server-side but never runs `setup_lobby_mirror`, reproducing the original stranding bug.

## Depends on
Merge both before this PR:

- Balatro-Multiplayer/BalatroMultiplayerAPI#7 adds `MPAPI.matchmaking.guard_queued` and the overlay. The call here is not nil-guarded, so running against an API without that helper errors at these entry points.
- Balatro-Multiplayer/BalatroMultiplayerAPI#10 gives api_client a FIFO response queue. "Leave Queue & Continue" fires a leave and a join/create back to back; without the FIFO fix the overlapping requests clobber the single callback slot, so one callback never fires and the other gets the wrong response body.

## What it looks like

Clicking a lobby create/join button while searching shows the shared guard overlay (from the API's queue-guard PR) instead of silently stranding the queue — with the search visibly running in the status panel:

![queue guard overlay](https://raw.githubusercontent.com/ChronoFinale/BalatroMultiplayerDevTools/master/docs/gallery/09-queue-guard-overlay.png)

Full annotated gallery of the guard's behavior (every entry point, every button outcome): [VERIFICATION.md](https://github.com/ChronoFinale/BalatroMultiplayerDevTools/blob/master/docs/VERIFICATION.md)
