### PR TITLE
MLBa ruleset: add bloodstone rework, idol TheOrder, hide enemy location, timer threshold

### DIFF
--- a/compatibility/TheOrder.lua
+++ b/compatibility/TheOrder.lua
@@ -29,7 +29,7 @@ end
 -- Patches idol RNG when using the order to sort deck based on count of identical cards instead of default deck order
 local original_reset_idol_card = reset_idol_card
 function reset_idol_card()
-	if MP.should_use_the_order() then
+	if MP.should_use_the_order() or MP.is_major_league_ruleset() then
 
 		G.GAME.current_round.idol_card.rank = "Ace"
 		G.GAME.current_round.idol_card.suit = "Spades"

--- a/core.lua
+++ b/core.lua
@@ -199,6 +199,8 @@ function MP.reset_lobby_config(persist_ruleset_and_gamemode)
 		legacy_smallworld = false,
 		-- Baseline off; start_lobby sets it on for standard-layer rulesets.
 		hide_score_until_played = false,
+		enemy_location_disabled = false,
+		timer_display_threshold = 0,
 	}
 end
 MP.reset_lobby_config()
@@ -247,6 +249,7 @@ function MP.reset_game_states()
 		timer_started = false,
         nemesis_timer_started = false,
         nemesis_timer_was_started = false,
+		timer_threshold_pending = false,
 		timer_consumed = false,
 		pvp_reached = false,
         pvp_reached_first = false,

--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -103,6 +103,7 @@ local function action_rejoinedLobby(p)
 	MP.self_reconnect_countdown = nil
 	MP.GAME.timer_started = false
 	MP.GAME.nemesis_timer_started = false
+	MP.GAME.timer_threshold_pending = false
 	MP.ACTIONS.sync_client()
 	MP.ACTIONS.lobby_info()
 	MP.UI.update_connection_status()
@@ -156,6 +157,7 @@ local function action_enemyDisconnected(p)
 
 	MP.GAME.timer_started = false
 	MP.GAME.nemesis_timer_started = false
+	MP.GAME.timer_threshold_pending = false
 
 	MP.enemy_disconnect_countdown = {
 		end_time = love.timer.getTime() + timeout,
@@ -256,6 +258,7 @@ local function action_reconnecting()
 		MP.LOBBY.connected = false
 		MP.GAME.timer_started = false
 		MP.GAME.nemesis_timer_started = false
+		MP.GAME.timer_threshold_pending = false
 		MP.UI.update_connection_status()
 		sendWarnMessage("Connection lost, attempting to reconnect...", "MULTIPLAYER")
 
@@ -322,6 +325,7 @@ local function begin_pvp_blind()
         MP.GAME.timer_started = false
         MP.GAME.nemesis_timer_started = false
         MP.GAME.nemesis_timer_was_started = false
+        MP.GAME.timer_threshold_pending = false
         MP.GAME.timer_consumed = false
         MP.GAME.timer = MP.UTILS.pvp_timer_base()
 	else
@@ -483,6 +487,7 @@ local function action_end_pvp(p)
 	MP.GAME.timer_started = false
 	MP.GAME.nemesis_timer_started = false
     MP.GAME.nemesis_timer_was_started = false
+	MP.GAME.timer_threshold_pending = false
 	MP.GAME.ready_blind = false
 	MP.GAME.pvp_reached = false
     MP.GAME.pvp_reached_first = false
@@ -499,6 +504,7 @@ local function action_end_pvp(p)
                     MP.GAME.nemesis_timer_started = false
                     MP.GAME.nemesis_timer_was_started = false
                     MP.GAME.pvp_timer_activated = false
+                    MP.GAME.timer_threshold_pending = false
                     return true
                 end,
             }))
@@ -1337,12 +1343,19 @@ end
 
 function MP.ACTIONS.start_ante_timer()
 	local is_pvp = MP.is_pvp_boss() and MP.is_layer_active("pvp_timer")
-	Client.send({
-		action = "startAnteTimer",
-		time = MP.GAME.timer,
-		isPvP = is_pvp or nil,
-	})
+	local threshold = MP.LOBBY.config.timer_display_threshold or 0
+
 	action_start_ante_timer({ time = MP.GAME.timer, fromNemesis = false })
+
+	if threshold > 0 and MP.GAME.timer > threshold then
+		MP.GAME.timer_threshold_pending = true
+	else
+		Client.send({
+			action = "startAnteTimer",
+			time = MP.GAME.timer,
+			isPvP = is_pvp or nil,
+		})
+	end
 end
 
 function MP.ACTIONS.pause_ante_timer()

--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -451,7 +451,7 @@ local function action_enemy_info(p)
 		play_sound("holo1", 0.865, 0.9)
 		play_sound("gong", 0.765, 0.4)
 	end
-	if MP.GAME.enemy.skips < skips then
+	if MP.GAME.enemy.skips < skips and not MP.LOBBY.config.enemy_location_disabled then
 		play_sound("negative", 0.865, 0.4)
 		play_sound("gong", 0.765, 0.4)
 	end

--- a/rulesets/majorleague.lua
+++ b/rulesets/majorleague.lua
@@ -7,7 +7,8 @@ MP.Ruleset({
 	banned_enhancements = {},
 	banned_tags = {},
 	banned_blinds = {},
-	reworked_jokers = {},
+	banned_silent = { "j_bloodstone" },
+	reworked_jokers = { "j_mp_bloodstone" },
 	reworked_consumables = {},
 	reworked_vouchers = {},
 	reworked_enhancements = {},
@@ -23,6 +24,8 @@ MP.Ruleset({
 		MP.LOBBY.config.timer_forgiveness = 1
 		MP.LOBBY.config.the_order = false
 		MP.LOBBY.config.preview_disabled = true
+		MP.LOBBY.config.enemy_location_disabled = true
+		MP.LOBBY.config.timer_display_threshold = 180
 		return true
 	end,
 }):inject()

--- a/tests/ruleset_shape.snapshot.lua
+++ b/tests/ruleset_shape.snapshot.lua
@@ -364,6 +364,9 @@ return {
     ["banned_consumables"] = {},
     ["banned_enhancements"] = {},
     ["banned_jokers"] = {},
+    ["banned_silent"] = {
+      "j_bloodstone",
+    },
     ["banned_tags"] = {},
     ["banned_vouchers"] = {},
     ["forced_gamemode"] = "gamemode_mp_attrition",
@@ -373,7 +376,9 @@ return {
     ["reworked_blinds"] = {},
     ["reworked_consumables"] = {},
     ["reworked_enhancements"] = {},
-    ["reworked_jokers"] = {},
+    ["reworked_jokers"] = {
+      "j_mp_bloodstone",
+    },
     ["reworked_tags"] = {},
     ["reworked_vouchers"] = {},
   },

--- a/ui/game/game_state.lua
+++ b/ui/game/game_state.lua
@@ -332,7 +332,7 @@ function Game:update_shop(dt)
 		updated_location = true
 		MP.ACTIONS.set_location("loc_shop")
 		MP.GAME.spent_before_shop = to_big(MP.GAME.spent_total) + to_big(0)
-		if MP.UI.show_enemy_location then MP.UI.show_enemy_location() end
+		if MP.UI.show_enemy_location and not MP.LOBBY.config.enemy_location_disabled then MP.UI.show_enemy_location() end
 	end
 	if G.STATE_COMPLETE and updated_location then updated_location = false end
 	update_shop_ref(self, dt)
@@ -344,7 +344,7 @@ function Game:update_blind_select(dt)
 	if MP.LOBBY.code and not G.STATE_COMPLETE and not updated_location then
 		updated_location = true
 		MP.ACTIONS.set_location("loc_selecting")
-		if MP.UI.show_enemy_location then MP.UI.show_enemy_location() end
+		if MP.UI.show_enemy_location and not MP.LOBBY.config.enemy_location_disabled then MP.UI.show_enemy_location() end
 	end
 	if G.STATE_COMPLETE and updated_location then updated_location = false end
 	update_blind_select_ref(self, dt)

--- a/ui/game/timer.lua
+++ b/ui/game/timer.lua
@@ -86,12 +86,14 @@ function MP.UI.timer_hud()
 											ref_table = setmetatable({}, {
 												__index = function()
 													if not MP.GAME.timer then return 0 end
-													-- All numbers bigger then 10 - display as integer
-													-- Also accounting for rounding to prevent 10.0 to be displayed
+													local threshold = MP.LOBBY.config.timer_display_threshold or 0
+													if threshold > 0 and MP.GAME.timer > threshold
+														and not MP.GAME.timer_started and not MP.GAME.nemesis_timer_started then
+														return string.format("%d", threshold)
+													end
 													if MP.GAME.timer > 9.95 then
 														return string.format("%d", MP.GAME.timer)
 													end
-													-- Less than 10 - display decimal part
 													return string.format("%.1f", MP.GAME.timer)
 												end,
 											}),
@@ -469,6 +471,18 @@ function Game:update(dt)
 	local speedup = is_pvp_timer and 1 or MP.current_ruleset().timer_speedup_multiplier or 1
 	local tick_mult = MP.GAME.nemesis_timer_started and speedup or 1
 	MP.GAME.timer = math.max(0, MP.GAME.timer - timer_dt * tick_mult)
+
+	if MP.GAME.timer_threshold_pending then
+		local threshold = MP.LOBBY.config.timer_display_threshold or 0
+		if MP.GAME.timer <= threshold then
+			MP.GAME.timer_threshold_pending = false
+			Client.send({
+				action = "startAnteTimer",
+				time = threshold,
+				isPvP = (MP.is_pvp_boss() and MP.is_layer_active("pvp_timer")) or nil,
+			})
+		end
+	end
 
 	if MP.GAME.timer == 0 then
 		MP.GAME.timer_consumed = true


### PR DESCRIPTION
- Enable reworked bloodstone (j_mp_bloodstone) and silently ban vanilla bloodstone
- Gate idol RNG normalization with MP.is_major_league_ruleset()
- Add enemy_location_disabled config to hide opponent location HUD
- Add timer_display_threshold: delay startAnteTimer network message until
  timer crosses threshold; presser sees full countdown, opponent sees static
  threshold value until the message arrives
- Update snapshot test for majorleague ruleset shape
