### PR TITLE
Log each idol hit for the website log parser

### DIFF
--- a/compatibility/TheOrder.lua
+++ b/compatibility/TheOrder.lua
@@ -333,6 +333,28 @@ function reset_idol_card()
 				G.GAME.current_round.idol_card.rank = idol_card.base.value
 				G.GAME.current_round.idol_card.suit = idol_card.base.suit
 				G.GAME.current_round.idol_card.id   = idol_card.base.id
+
+				-- Log the hit so the website log parser can show which card won and
+				-- how likely it was. Cards are compact "<rank><suit><count>" tokens
+				-- in selection order (T = 10), base64'd so the line stays one token:
+				--   IDOL_ROLL::<base64 of
+				--     {"roll":0.62,"winner":"QH","cards":["KS4","QH3","AS1"]}>
+				local rank_codes = { Ace = "A", King = "K", Queen = "Q", Jack = "J", ["10"] = "T" }
+				local function card_token(value, suit)
+					return (rank_codes[value] or tostring(value)) .. tostring(suit):sub(1, 1)
+				end
+				local tokens = {}
+				for _, reel_entry in ipairs(valid_idol_cards) do
+					tokens[#tokens + 1] = string.format('"%s%s"', card_token(reel_entry.value, reel_entry.suit), tostring(reel_entry.count))
+				end
+				local idol_payload = string.format(
+					'{"roll":%s,"winner":"%s","cards":[%s]}',
+					tostring(raw_random),
+					card_token(idol_card.base.value, idol_card.base.suit),
+					table.concat(tokens, ",")
+				)
+				sendDebugMessage("IDOL_ROLL::" .. love.data.encode("string", "base64", idol_payload), "IdolAlgo")
+
 				break
 			end
 		end


### PR DESCRIPTION
# Log each idol hit for the website log parser

The Order weights the idol card by how many copies of each card are in the deck,
so some idols are far likelier than others — but once the roll happens none of
that is visible. This logs it so the website log parser can show it
([website PR](https://github.com/Balatro-Multiplayer/www/pull/55)).

22 lines in `compatibility/TheOrder.lua`, emitted once per selection right after
the winning card is stored:

```
IDOL_ROLL::<base64 of {"roll":0.62,"winner":"QH","cards":["KS4","QH3","AS1"]}>
```

`cards` are `<rank><suit><count>` tokens (T = 10) **in the same order as the
weighted threshold walk**, so a reader can reconstruct the exact distribution the
roll was made against. base64 keeps it to one opaque token in the log.

## Notes

- **Logging only** — no game state, no RNG draws, nothing that could desync. It
  reports `raw_random`, already computed on the line above.
- **No new dependencies** — `sendDebugMessage` and `love.data.encode`, both
  already used elsewhere (`lib/serialization.lua:43`). No `json` require, so
  nothing depends on module load order.
- Categorised under the existing `IdolAlgo` logger. ~330 chars per blind for a
  full 52-card deck. Only fires under The Order.
- Suits are encoded by first letter, so a modded custom suit starting with
  S/H/C/D would collide. Base-game suits are unambiguous.

Verified in a live game (one line per blind, decodes as expected) and by running
the emit logic under LuaJIT and feeding its output through the website parser —
an independent threshold walk confirms the declared winner is the one the roll
selects. `loadfile` syntax check passes.
