### PR TITLE
Retract time for skipping

### DIFF
--- a/compatibility/Preview/InitPreview.lua
+++ b/compatibility/Preview/InitPreview.lua
@@ -55,7 +55,7 @@ function FN.PRE.start_new_coroutine()
                 and not MP.GAME.nemesis_timer_started
                 and not MP.GAME.timer_consumed
             then
-                MP.UI.consume_timer(timer_cost, nil, math.max(10, timer_cost))
+                MP.UI.consume_timer(timer_cost, nil, 10)
             end
             return true
         end

--- a/core.lua
+++ b/core.lua
@@ -226,6 +226,7 @@ function MP.reset_game_states()
 			info_received = false,
 			location = localize("loc_selecting"),
 			skips = 0,
+            skips_before_pvp = 0,
 			lives = MP.LOBBY.config.starting_lives,
 			sells = 0,
 			sells_per_ante = {},
@@ -268,6 +269,8 @@ function MP.reset_game_states()
 		},
         pvp_timer_order = nil,
         pvp_timer_activated = false,
+        skips_before_pvp = 0,
+        skips_difference = 0,
 	}
 end
 MP.reset_game_states()

--- a/core.lua
+++ b/core.lua
@@ -246,6 +246,7 @@ function MP.reset_game_states()
 		highest_score = MP.INSANE_INT.empty(),
 		timer = MP.UTILS.timer_base(),
 		timer_started = false,
+        timer_was_started = false,
         nemesis_timer_started = false,
         nemesis_timer_was_started = false,
 		timer_consumed = false,

--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -319,6 +319,9 @@ end
 local function begin_pvp_blind()
 	if MP.GAME.next_blind_context then
 		G.FUNCS.select_blind(MP.GAME.next_blind_context)
+        MP.GAME.enemy.skips_before_pvp = 0
+        MP.GAME.skips_before_pvp = 0
+        MP.GAME.skips_difference = 0
         MP.GAME.timer_started = false
         MP.GAME.nemesis_timer_started = false
         MP.GAME.nemesis_timer_was_started = false
@@ -338,6 +341,9 @@ local function action_start_blind(p)
 	MP.GAME.enemy.score_text = "0"
 	-- Re-mask the opponent's hands until the first enemyInfo of the new blind.
 	MP.GAME.enemy.info_received = false
+    MP.GAME.enemy.skips_before_pvp = 0
+    MP.GAME.skips_before_pvp = 0
+    MP.GAME.skips_difference = 0
 	MP.GAME.ready_blind = false
 	MP.GAME.pvp_reached = false
     MP.GAME.pvp_timer_order = nil
@@ -356,6 +362,9 @@ local function action_enemy_info(p)
 	if skips and MP.GAME.enemy.skips ~= skips then
 		for i = 1, skips - MP.GAME.enemy.skips do
 			MP.GAME.enemy.spent_in_shop[#MP.GAME.enemy.spent_in_shop + 1] = 0
+            MP.GAME.enemy.skips_before_pvp = (MP.GAME.enemy.skips_before_pvp or 0) + 1
+            MP.UI.update_matching_skip_timer(true)
+
 			if
 				MP.GAME.enemy.skips < skips
 				and MP.LOBBY.config.timer
@@ -377,49 +386,51 @@ local function action_enemy_info(p)
     if score then
         if MP.INSANE_INT.greater_than(score, MP.GAME.enemy.highest_score) then MP.GAME.enemy.highest_score = score end
 
-        G.E_MANAGER:add_event(Event({
-            blockable = false,
-            blocking = false,
-            trigger = "ease",
-            delay = 0.75,
-            timer = "REAL",
-            ref_table = MP.GAME.enemy.score,
-            ref_value = "e_count",
-            ease_to = score.e_count,
-            func = function(t)
-                return math.floor(t)
-            end,
-        }))
-
-        G.E_MANAGER:add_event(Event({
-            blockable = false,
-            blocking = false,
-            trigger = "ease",
-            delay = 0.75,
-            timer = "REAL",
-            ref_table = MP.GAME.enemy.score,
-            ref_value = "coeffiocient", -- why is this misspelled
-            ease_to = score.coeffiocient,
-            func = function(t)
-                local mult = 1
-                if score.exponent > 0 then mult = 100 end
-                return math.floor(t * mult) / mult
-            end,
-        }))
-
-        G.E_MANAGER:add_event(Event({
-            blockable = false,
-            blocking = false,
-            trigger = "ease",
-            delay = 0.75,
-            timer = "REAL",
-            ref_table = MP.GAME.enemy.score,
-            ref_value = "exponent",
-            ease_to = score.exponent,
-            func = function(t)
-                return math.floor(t)
-            end,
-        }))
+        if not MP.INSANE_INT.equal(MP.GAME.enemy.score, score) then
+            G.E_MANAGER:add_event(Event({
+                blockable = false,
+                blocking = false,
+                trigger = "ease",
+                delay = 0.75,
+                timer = "REAL",
+                ref_table = MP.GAME.enemy.score,
+                ref_value = "e_count",
+                ease_to = score.e_count,
+                func = function(t)
+                    return math.floor(t)
+                end,
+            }))
+    
+            G.E_MANAGER:add_event(Event({
+                blockable = false,
+                blocking = false,
+                trigger = "ease",
+                delay = 0.75,
+                timer = "REAL",
+                ref_table = MP.GAME.enemy.score,
+                ref_value = "coeffiocient", -- why is this misspelled
+                ease_to = score.coeffiocient,
+                func = function(t)
+                    local mult = 1
+                    if score.exponent > 0 then mult = 100 end
+                    return math.floor(t * mult) / mult
+                end,
+            }))
+    
+            G.E_MANAGER:add_event(Event({
+                blockable = false,
+                blocking = false,
+                trigger = "ease",
+                delay = 0.75,
+                timer = "REAL",
+                ref_table = MP.GAME.enemy.score,
+                ref_value = "exponent",
+                ease_to = score.exponent,
+                func = function(t)
+                    return math.floor(t)
+                end,
+            }))
+        end
 
         MP.GAME.enemy.real_score = score
         MP.GAME.enemy.info_received = true

--- a/networking/action_handlers.lua
+++ b/networking/action_handlers.lua
@@ -323,6 +323,7 @@ local function begin_pvp_blind()
         MP.GAME.skips_before_pvp = 0
         MP.GAME.skips_difference = 0
         MP.GAME.timer_started = false
+        MP.GAME.timer_was_started = false
         MP.GAME.nemesis_timer_started = false
         MP.GAME.nemesis_timer_was_started = false
         MP.GAME.timer_consumed = false
@@ -492,6 +493,7 @@ local function action_end_pvp(p)
 	MP.GAME.timer = MP.UTILS.timer_base()
 	MP.GAME.timer_consumed = false
 	MP.GAME.timer_started = false
+    MP.GAME.timer_was_started = false
 	MP.GAME.nemesis_timer_started = false
     MP.GAME.nemesis_timer_was_started = false
 	MP.GAME.ready_blind = false
@@ -507,6 +509,7 @@ local function action_end_pvp(p)
                 func = function()
                     MP.GAME.timer = MP.UTILS.timer_base()
                     MP.GAME.timer_started = false
+                    MP.GAME.timer_was_started = false
                     MP.GAME.nemesis_timer_started = false
                     MP.GAME.nemesis_timer_was_started = false
                     MP.GAME.pvp_timer_activated = false
@@ -1058,6 +1061,7 @@ local function action_start_ante_timer(p)
         MP.GAME.nemesis_timer_was_started = true
 	else
 		MP.GAME.timer_started = true
+        MP.GAME.timer_was_started = true
 	end
 end
 

--- a/ui/game/functions.lua
+++ b/ui/game/functions.lua
@@ -83,18 +83,8 @@ local skip_blind_ref = G.FUNCS.skip_blind
 G.FUNCS.skip_blind = function(e)
 	skip_blind_ref(e)
 	if MP.LOBBY.code then
-		-- Old timer: add time from skipping to own timer when not timered and not timering
-		if
-            MP.LOBBY.config.timer
-			and not MP.GAME.timer_started
-			and not MP.GAME.nemesis_timer_started
-            and not MP.GAME.timer_consumed
-            and not MP.GAME.nemesis_timer_was_started
-            and not MP.is_any_layer_active({ "no_animation_timer", "pressure_timer" })
-			and (MP.LOBBY.config.timer_increment_seconds or 0) > 0
-        then
-            MP.UI.restore_timer(MP.LOBBY.config.timer_increment_seconds)
-		end
+        MP.GAME.skips_before_pvp = (MP.GAME.skips_before_pvp or 0) + 1
+        MP.UI.update_matching_skip_timer(false)
 
 		MP.ACTIONS.skip(G.GAME.skips)
 		MP.RLOG.record("skip_blind", 0, "action:skipBlind")

--- a/ui/game/timer.lua
+++ b/ui/game/timer.lua
@@ -523,6 +523,41 @@ function MP.UI.restore_timer(amount, silent, max_timer)
 	end
 end
 
+-- Update skips difference between 2 players.
+-- If value increased - one player skipped even further, add time.
+-- If value decreased - another player catches up, deduct time.
+function MP.UI.update_matching_skip_timer(from_nemesis)
+    local new_diff = math.abs((MP.GAME.skips_before_pvp or 0) - (MP.GAME.enemy.skips_before_pvp or 0))
+    local skips_dx = new_diff - (MP.GAME.skips_difference or 0)
+    MP.GAME.skips_difference = new_diff
+
+    if skips_dx > 0 then
+        if
+            MP.LOBBY.config.timer
+			and not MP.GAME.timer_started
+			and not MP.GAME.nemesis_timer_started
+            and not MP.GAME.timer_consumed
+            and not MP.GAME.nemesis_timer_was_started
+            and not MP.is_any_layer_active({ "no_animation_timer", "pressure_timer" })
+			and (MP.LOBBY.config.timer_increment_seconds or 0) > 0
+        then
+            MP.UI.restore_timer(MP.LOBBY.config.timer_increment_seconds)
+		end
+    elseif skips_dx < 0 then
+        if
+            MP.LOBBY.config.timer
+			and not MP.GAME.timer_started
+			and not MP.GAME.nemesis_timer_started
+            and not MP.GAME.timer_consumed
+            and not MP.GAME.nemesis_timer_was_started
+            and not MP.is_any_layer_active({ "no_animation_timer", "pressure_timer" })
+			and (MP.LOBBY.config.timer_increment_seconds or 0) > 0
+        then
+            MP.UI.consume_timer(MP.LOBBY.config.timer_increment_seconds, false, 10)
+		end
+    end
+end
+
 local old_play = G.FUNCS.play_cards_from_highlighted
 function G.FUNCS.play_cards_from_highlighted(...)
 	-- Carbon: capture which hand slots are played BEFORE old_play consumes them.

--- a/ui/game/timer.lua
+++ b/ui/game/timer.lua
@@ -531,24 +531,21 @@ function MP.UI.update_matching_skip_timer(from_nemesis)
     local skips_dx = new_diff - (MP.GAME.skips_difference or 0)
     MP.GAME.skips_difference = new_diff
 
+    -- Same implementation twice is in case of future changes how this should work.
     if skips_dx > 0 then
         if
             MP.LOBBY.config.timer
-			and not MP.GAME.timer_started
-			and not MP.GAME.nemesis_timer_started
-            and not MP.GAME.timer_consumed
+            and not MP.GAME.timer_was_started
             and not MP.GAME.nemesis_timer_was_started
             and not MP.is_any_layer_active({ "no_animation_timer", "pressure_timer" })
 			and (MP.LOBBY.config.timer_increment_seconds or 0) > 0
         then
-            MP.UI.restore_timer(MP.LOBBY.config.timer_increment_seconds)
+            MP.UI.restore_timer(MP.LOBBY.config.timer_increment_seconds, false)
 		end
     elseif skips_dx < 0 then
         if
             MP.LOBBY.config.timer
-			and not MP.GAME.timer_started
-			and not MP.GAME.nemesis_timer_started
-            and not MP.GAME.timer_consumed
+            and not MP.GAME.timer_was_started
             and not MP.GAME.nemesis_timer_was_started
             and not MP.is_any_layer_active({ "no_animation_timer", "pressure_timer" })
 			and (MP.LOBBY.config.timer_increment_seconds or 0) > 0

--- a/ui/game/timer.lua
+++ b/ui/game/timer.lua
@@ -487,9 +487,17 @@ function Game:update(dt)
 	end
 end
 
+-- Decrease timer up to specified minimum & juice up timer UI
 function MP.UI.consume_timer(amount, silent, min_timer)
-	if amount > 0 and MP.LOBBY.config.timer and MP.GAME.timer and MP.GAME.timer > (min_timer or 0) then
-		MP.GAME.timer = math.max(0, MP.GAME.timer - amount)
+    if not MP.GAME.timer or not MP.LOBBY.config.timer then return end
+    amount = math.max(0, amount)
+    min_timer = min_timer or 0
+
+    local new_timer = math.max(0, min_timer, MP.GAME.timer - amount)
+    amount = MP.GAME.timer - new_timer
+
+	if amount > 0 then
+		MP.GAME.timer = new_timer
 		if not silent then
 			local timer_ui = G.HUD:get_UIE_by_ID("timer_UI_count")
 			if timer_ui then timer_ui.config.object:juice_up() end
@@ -497,9 +505,17 @@ function MP.UI.consume_timer(amount, silent, min_timer)
 	end
 end
 
+-- Increase timer up to specified maximum & juice up timer UI
 function MP.UI.restore_timer(amount, silent, max_timer)
-	if amount > 0 and MP.LOBBY.config.timer and MP.GAME.timer and (not max_timer or MP.GAME.timer < max_timer) then
-		MP.GAME.timer = math.max(0, MP.GAME.timer + amount)
+    if not MP.GAME.timer or not MP.LOBBY.config.timer then return end
+    amount = math.max(0, amount)
+    max_timer = max_timer or (MP.GAME.timer + amount)
+
+    local new_timer = math.max(0, math.min(MP.GAME.timer + amount, max_timer))
+    amount = new_timer - MP.GAME.timer
+
+	if amount > 0 then
+		MP.GAME.timer = new_timer
 		if not silent then
 			local timer_ui = G.HUD:get_UIE_by_ID("timer_UI_count")
 			if timer_ui then timer_ui.config.object:juice_up() end


### PR DESCRIPTION
This PR implements a proposal by pool: If both players skip a blind the ante timer should not increase.

- When P1 skips, they gain time.
- When P2 skips in same period between PvP (Ante 1-2 and then every Ante), they lose time.
  - Which exact blind skipped doesn't matter, only amount of skips matters.
- If any of players was timered, mentioned rules does not apply and nothing happens until new ante.
  - Which means if P1 double skip and immediately timer opponent, P2 will not lose a time for skipping in this ante.
- Applied to "old timer" only. No-Animation and Pressure timer works differently and not widely used yet, so no new mechanics for them.