### PR TITLE
Fix timer threshold: show real timer value instead of capping display

### DIFF
--- a/ui/game/timer.lua
+++ b/ui/game/timer.lua
@@ -86,11 +86,6 @@ function MP.UI.timer_hud()
 											ref_table = setmetatable({}, {
 												__index = function()
 													if not MP.GAME.timer then return 0 end
-													local threshold = MP.LOBBY.config.timer_display_threshold or 0
-													if threshold > 0 and MP.GAME.timer > threshold
-														and not MP.GAME.timer_started and not MP.GAME.nemesis_timer_started then
-														return string.format("%d", threshold)
-													end
 													if MP.GAME.timer > 9.95 then
 														return string.format("%d", MP.GAME.timer)
 													end


### PR DESCRIPTION
## Summary

- Removes the HUD display threshold that was visually capping the timer at 180, making skip bonuses invisible
- The local player now always sees their real timer value (e.g., 240 after a skip) and watches it count down
- The `timer_display_threshold` config still controls when the `startAnteTimer` network message is sent to the opponent — that logic is unchanged and correct

## Context

The previous implementation added a threshold check to the timer HUD `__index` function that returned the threshold value (180) whenever the timer was above it and hadn't started. This made it look like the timer was capped at 180 rather than delaying the network message. The intended behavior is: presser sees their full timer counting down from 240, opponent doesn't receive `startAnteTimer` until it crosses 180.

## Test plan

- [ ] Skip a blind in MLBa — timer should visually increase above 180 (e.g., to 240)
- [ ] Press the timer button with timer at 240 — local timer counts down from 240, opponent sees no timer start
- [ ] When timer crosses 180 — opponent receives `startAnteTimer` and their timer starts at 180

---
_Generated by [Claude Code](https://claude.ai/code/session_01MuDBRvAF5nx9htEHCW2WqZ)_