### PR TITLE
MLBa: remove life forgiveness, hide skips with timer threshold

### DIFF
--- a/rulesets/majorleague.lua
+++ b/rulesets/majorleague.lua
@@ -21,7 +21,7 @@ MP.Ruleset({
 	end,
 	force_lobby_options = function(self)
 		MP.LOBBY.config.timer_base_seconds = 180
-		MP.LOBBY.config.timer_forgiveness = 1
+		MP.LOBBY.config.timer_forgiveness = 0
 		MP.LOBBY.config.the_order = false
 		MP.LOBBY.config.preview_disabled = true
 		MP.LOBBY.config.enemy_location_disabled = true

--- a/ui/game/lobby_info.lua
+++ b/ui/game/lobby_info.lua
@@ -230,7 +230,7 @@ function MP.UI.create_UIBox_player_row(type)
 					},
 				},
 			},
-			{
+			(MP.LOBBY.config.timer_display_threshold or 0) <= 0 and {
 				n = G.UIT.C,
 				config = { align = "cm" },
 				nodes = {
@@ -291,7 +291,7 @@ function MP.UI.create_UIBox_player_row(type)
 					-- 	},
 					-- },
 				},
-			},
+			} or nil,
 			{
 				n = G.UIT.C,
 				config = { align = "cm", padding = 0.05, colour = G.C.L_BLACK, r = 0.1, minw = 3, maxw = 3 },

--- a/ui/game/timer.lua
+++ b/ui/game/timer.lua
@@ -86,11 +86,6 @@ function MP.UI.timer_hud()
 											ref_table = setmetatable({}, {
 												__index = function()
 													if not MP.GAME.timer then return 0 end
-													local threshold = MP.LOBBY.config.timer_display_threshold or 0
-													if threshold > 0 and MP.GAME.timer > threshold
-														and not MP.GAME.timer_started and not MP.GAME.nemesis_timer_started then
-														return string.format("%d", threshold)
-													end
 													if MP.GAME.timer > 9.95 then
 														return string.format("%d", MP.GAME.timer)
 													end


### PR DESCRIPTION
## Summary

- Remove first life forgiveness from MLBa (`timer_forgiveness` 1 → 0)
- Hide skip count in lobby info menu when `timer_display_threshold` is set, since the count leaks how much bonus time the opponent has accumulated
- Also includes the prior fix: remove HUD display cap so the local player sees their real timer value after skipping

## Test plan

- [ ] MLBa game: first timer failure should cost a life (no forgiveness)
- [ ] MLBa lobby info menu: skip count column should not appear
- [ ] Non-MLBa rulesets: skip count still displays normally

---
_Generated by [Claude Code](https://claude.ai/code/session_01MuDBRvAF5nx9htEHCW2WqZ)_