### PR TITLE
Disable matching skip timer when timer_display_threshold is set

### DIFF
--- a/ui/game/timer.lua
+++ b/ui/game/timer.lua
@@ -536,6 +536,8 @@ end
 -- If value increased - one player skipped even further, add time.
 -- If value decreased - another player catches up, deduct time.
 function MP.UI.update_matching_skip_timer(from_nemesis)
+    if (MP.LOBBY.config.timer_display_threshold or 0) > 0 then return end
+
     local new_diff = math.abs((MP.GAME.skips_before_pvp or 0) - (MP.GAME.enemy.skips_before_pvp or 0))
     local skips_dx = new_diff - (MP.GAME.skips_difference or 0)
     MP.GAME.skips_difference = new_diff


### PR DESCRIPTION
## Summary

- Early-return from `MP.UI.update_matching_skip_timer()` when `timer_display_threshold > 0`
- The matching skip system (restore/consume timer based on skip difference) conflicts with the timer threshold — the threshold hides skip advantage by delaying `startAnteTimer`, but the matching system reveals it by adjusting both players' timers and juicing the UI on each skip

## Test plan

- [ ] MLBa: skip a blind — timer should increase by 60s, no timer adjustment on opponent's side
- [ ] MLBa: both players skip — no matching skip time deduction occurs
- [ ] Non-MLBa rulesets (threshold=0): matching skip timer still works normally

---
_Generated by [Claude Code](https://claude.ai/code/session_01MuDBRvAF5nx9htEHCW2WqZ)_