### PR TITLE
Fix timer threshold: local skips add time, enemy skips ignored

### DIFF
--- a/ui/game/timer.lua
+++ b/ui/game/timer.lua
@@ -536,7 +536,18 @@ end
 -- If value increased - one player skipped even further, add time.
 -- If value decreased - another player catches up, deduct time.
 function MP.UI.update_matching_skip_timer(from_nemesis)
-    if (MP.LOBBY.config.timer_display_threshold or 0) > 0 then return end
+    if (MP.LOBBY.config.timer_display_threshold or 0) > 0 then
+        if not from_nemesis
+            and MP.LOBBY.config.timer
+            and not MP.GAME.timer_was_started
+            and not MP.GAME.nemesis_timer_was_started
+            and not MP.is_any_layer_active({ "no_animation_timer", "pressure_timer" })
+            and (MP.LOBBY.config.timer_increment_seconds or 0) > 0
+        then
+            MP.UI.restore_timer(MP.LOBBY.config.timer_increment_seconds, false)
+        end
+        return
+    end
 
     local new_diff = math.abs((MP.GAME.skips_before_pvp or 0) - (MP.GAME.enemy.skips_before_pvp or 0))
     local skips_dx = new_diff - (MP.GAME.skips_difference or 0)


### PR DESCRIPTION
## Summary

- When `timer_display_threshold > 0`, the local player's skip still adds time (e.g., 180 → 240) — they see the full value
- Enemy skips are ignored — no matching skip retraction, no timer juice, no information leaked
- The opponent only learns the timer was pressed when it ticks down to the threshold and `startAnteTimer` is sent

## Context

The previous fix disabled `update_matching_skip_timer` entirely when threshold was set, which also prevented the local player's timer from increasing past 180 on skip. Now it early-returns after adding time for local skips only.

## Test plan

- [ ] MLBa: skip a blind — timer increases past 180 (e.g., to 240)
- [ ] MLBa: opponent skips — no timer adjustment on your side
- [ ] MLBa: press timer at 240 — counts down locally, `startAnteTimer` sent at 180
- [ ] Non-MLBa rulesets: matching skip timer still works normally

---
_Generated by [Claude Code](https://claude.ai/code/session_01MuDBRvAF5nx9htEHCW2WqZ)_