### PR TITLE
Clamp nemesis timer hover display to threshold

### DIFF
--- a/ui/game/timer.lua
+++ b/ui/game/timer.lua
@@ -162,13 +162,15 @@ function MP.UI.nemesis_timer_hud()
 														if not MP.GAME.enemy or not MP.GAME.enemy.last_timer then
 															return "0.0"
 														end
-														-- All numbers bigger then 10 - display as integer
-														-- Also accounting for rounding to prevent 10.0 to be displayed
-														if MP.GAME.enemy.last_timer > 9.95 then
-															return string.format("%d", MP.GAME.enemy.last_timer)
+														local val = MP.GAME.enemy.last_timer
+														local threshold = MP.LOBBY.config.timer_display_threshold or 0
+														if threshold > 0 and val > threshold then
+															val = threshold
 														end
-														-- Less than 10 - display decimal part
-														return string.format("%.1f", MP.GAME.enemy.last_timer)
+														if val > 9.95 then
+															return string.format("%d", val)
+														end
+														return string.format("%.1f", val)
 													end,
 												}),
 												ref_value = "timer",


### PR DESCRIPTION
## Summary

- Clamp the nemesis timer hover tooltip to `timer_display_threshold` so it doesn't leak the opponent's skip bonus (e.g., shows 180 instead of 240)

## Test plan

- [ ] MLBa: opponent has skip bonus (timer > 180) — hover shows 180, not the real value
- [ ] MLBa: opponent timer at or below 180 — hover shows the real value
- [ ] Non-MLBa rulesets: hover shows the real value as before

---
_Generated by [Claude Code](https://claude.ai/code/session_01MuDBRvAF5nx9htEHCW2WqZ)_