### PR TITLE
feat(the-order): log each idol hit for the website log parser

### DIFF
--- a/compatibility/TheOrder.lua
+++ b/compatibility/TheOrder.lua
@@ -333,6 +333,28 @@ function reset_idol_card()
 				G.GAME.current_round.idol_card.rank = idol_card.base.value
 				G.GAME.current_round.idol_card.suit = idol_card.base.suit
 				G.GAME.current_round.idol_card.id   = idol_card.base.id
+
+				-- Log the hit so the website log parser can show which card won and
+				-- how likely it was. Cards are compact "<rank><suit><count>" tokens
+				-- in selection order (T = 10), base64'd so the line stays one token:
+				--   IDOL_ROLL::<base64 of
+				--     {"roll":0.62,"winner":"QH","cards":["KS4","QH3","AS1"]}>
+				local rank_codes = { Ace = "A", King = "K", Queen = "Q", Jack = "J", ["10"] = "T" }
+				local function card_token(value, suit)
+					return (rank_codes[value] or tostring(value)) .. tostring(suit):sub(1, 1)
+				end
+				local tokens = {}
+				for _, reel_entry in ipairs(valid_idol_cards) do
+					tokens[#tokens + 1] = string.format('"%s%s"', card_token(reel_entry.value, reel_entry.suit), tostring(reel_entry.count))
+				end
+				local idol_payload = string.format(
+					'{"roll":%s,"winner":"%s","cards":[%s]}',
+					tostring(raw_random),
+					card_token(idol_card.base.value, idol_card.base.suit),
+					table.concat(tokens, ",")
+				)
+				sendDebugMessage("IDOL_ROLL::" .. love.data.encode("string", "base64", idol_payload), "IdolAlgo")
+
 				break
 			end
 		end


### PR DESCRIPTION
Re-lands the idol roll logging on `dev`.

#511 merged this into `main`, but `dev` never had it — and #518 (v0.5.3), cut
from `dev`, then overwrote `compatibility/TheOrder.lua` and stripped it back
out. So the change is currently in no shipping branch: `main`'s copy was
removed by the release, and `dev` never carried it.

Same commit, cherry-picked onto `dev`. One file, +22 lines, no behaviour change
beyond the log line.

### What it does

Under The Order the idol card is a weighted lottery over your deck — each card's
chance scales with how many copies you hold — but the roll happens at the start
of a blind and then vanishes. This logs it so the website log parser can show
the distribution the roll was made against.

`IDOL_ROLL::<base64 of {"roll":0.62,"winner":"QH","cards":["KS4","QH3","AS1"]}>`

Cards are `<rank><suit><count>` tokens in selection order (T = 10), base64'd so
the line stays a single token in the log. The website side is
Balatro-Multiplayer/www#55.

### Notes

- Sits inside the existing `raw_random < threshold` branch, right after the
  winner is assigned and before the `break`, so it fires exactly once per roll
  and only when a winner was actually picked.
- `valid_idol_cards` order is preserved, which is what lets the parser walk
  cumulative thresholds and land the roll in the winning slice.
- Verified emitting on a local 0.5.2 install: a full 52-card deck roll logged
  `{"roll":0.456…,"winner":"9D","cards":["AS1",…,"2D1"]}`, winner present in
  `cards`.
