### PR TITLE
Disable enemy location hover when enemy_location_disabled

### DIFF
--- a/ui/game/enemy_location.lua
+++ b/ui/game/enemy_location.lua
@@ -241,6 +241,7 @@ end
 
 G.FUNCS.mp_setup_hover_enemy_location_display = function(e)
 	e.config.func = nil
+	if MP.LOBBY.config.enemy_location_disabled then return end
 	e.states.collide.can = true
 	e.states.hover.can = true
 


### PR DESCRIPTION
The Round Score HUD element's hover tooltip still showed the enemy's location popup even when `enemy_location_disabled` was set to `true` (e.g. in the MLBa ruleset). This adds an early return in `mp_setup_hover_enemy_location_display` so the hover behavior is never wired up when the flag is on.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MuDBRvAF5nx9htEHCW2WqZ)_