### PR TITLE
Fix matching skip timer: use max instead of abs

### DIFF
--- a/ui/game/timer.lua
+++ b/ui/game/timer.lua
@@ -551,7 +551,7 @@ function MP.UI.update_matching_skip_timer(from_nemesis)
         return
     end
 
-    local new_diff = math.abs((MP.GAME.skips_before_pvp or 0) - (MP.GAME.enemy.skips_before_pvp or 0))
+    local new_diff = math.max((MP.GAME.skips_before_pvp or 0) - (MP.GAME.enemy.skips_before_pvp or 0), 0)
     local skips_dx = new_diff - (MP.GAME.skips_difference or 0)
     MP.GAME.skips_difference = new_diff
 


### PR DESCRIPTION
`math.abs` in `update_matching_skip_timer` gave both players bonus time based on the skip difference — meaning the player who skipped *less* also got extra time from their opponent's skips. Changed to `math.max(..., 0)` so only the player with more skips gets the bonus, and the player with fewer skips sees no timer change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MuDBRvAF5nx9htEHCW2WqZ)_